### PR TITLE
docs: Update instructions to start dev server

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ After cloning the repository, install the project dependencies, then run the bui
 ```bash
 npm install
 
-npm run serve
+npm run dev:eleventy
 ```
 
 This will start a server on http://localhost:8080 that will live reload whenever


### PR DESCRIPTION
The readme instruction on howto start a server locally to inspect ones
changes didnt' work. The task didn't exist. The proper task did exist,
but wasn't documented. This change fixes the readme with the proper
instructions.