### PR TITLE
analytics: Add Google Analytics

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -94,4 +94,13 @@ document.getElementById('nav-toggle').onclick = function(){
     classes.toggle("hidden");
 }
 </script>
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-2ZH9W82QL8"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-2ZH9W82QL8');
+</script>
 </html>


### PR DESCRIPTION
Currently we don't have any tracking at all on our website, and this
seemed like the fastest way to get started with it. Default Google
analytics script is used on each page now.