### PR TITLE
navigation: Sign in link to the FlowForge app

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -44,6 +44,7 @@
                         <li class="flex"><a class="flex-grow sm:px-4 sm:pl-0 sm:py-2" href="/about">about</a></li>
                         <li class="flex"><a href="/product">product</a></li>
                         <li class="flex"><a href="/blog">news</a></li>
+			<li class="flex"><a href="https://app.flowforge.com">sign in</a></li>
                         <li class="flex"><a href="https://github.com/flowforge" target="_blank">{% include "components/github.njk" %}</a></li>
                     </ul>
                 </nav>


### PR DESCRIPTION
Since yesterday external users might user the flowforge app. As such the
app should be more discoverable. Adding a "Sign in" item to the top
navigation should aid in that.

Closes https://github.com/flowforge/website/issues/76