### PR TITLE
Add security.txt

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -22,6 +22,7 @@ module.exports = function(eleventyConfig) {
     // eleventyConfig.addPassthroughCopy("src/js");
     eleventyConfig.addPassthroughCopy("src/CNAME");
     eleventyConfig.addPassthroughCopy({"src/favicon/*":"/"});
+    eleventyConfig.addPassthroughCopy("src/.well-known")
 
     eleventyConfig.addFilter("head", (array, n) => {
         if( n < 0 ) {

--- a/src/.well-known/security.txt
+++ b/src/.well-known/security.txt
@@ -1,0 +1,6 @@
+Contact: mailto:security@flowforge.com
+Expires: 2022-04-19T23:00:00.000Z
+Preferred-Languages: en
+Canonical: https://flowforge.com/security.txt
+Policy: https://github.com/flowforge/flowforge/blob/main/SECURITY.md
+


### PR DESCRIPTION
This adds a basic minimal security.txt file (https://securitytxt.org/)

We should also decide if we should sign this with a PGP key and include a public key for people to use to encrypt security reports when they send them via email?

This file will need to be updated with a new date 1 year from today.

Fixes https://github.com/flowforge/CloudProject/issues/44