### PR TITLE
rendering: Allow code-blocks in MarkDown

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -102,6 +102,9 @@ module.exports = function(eleventyConfig) {
         markdownItAnchorOptions
     )
 
+    const syntaxHighlight = require("@11ty/eleventy-plugin-syntaxhighlight");
+    eleventyConfig.addPlugin(syntaxHighlight);
+
     eleventyConfig.setLibrary("md", markdownLib)
 
     return {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
             "devDependencies": {
                 "@11ty/eleventy": "^0.12.1",
                 "@11ty/eleventy-plugin-rss": "^1.1.2",
+                "@11ty/eleventy-plugin-syntaxhighlight": "^4.0.0",
                 "@tailwindcss/typography": "^0.4.1",
                 "markdown-it-anchor": "^8.4.1",
                 "nodemon": "^2.0.15",
@@ -96,6 +97,20 @@
                 "debug": "^4.3.1",
                 "posthtml": "^0.15.1",
                 "posthtml-urls": "1.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/11ty"
+            }
+        },
+        "node_modules/@11ty/eleventy-plugin-syntaxhighlight": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@11ty/eleventy-plugin-syntaxhighlight/-/eleventy-plugin-syntaxhighlight-4.0.0.tgz",
+            "integrity": "sha512-t95DIZQ7MnaspgpmXyKIgz2TpyN7EshMt9+SFfqVUYKTISU3+T3FTXFscoLownyNWb/5EC0od69BnCZwEcMzCg==",
+            "dev": true,
+            "dependencies": {
+                "linkedom": "^0.13.2",
+                "prismjs": "^1.26.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -348,6 +363,31 @@
             "peerDependencies": {
                 "tailwindcss": ">=2.0.0"
             }
+        },
+        "node_modules/@types/linkify-it": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.2.tgz",
+            "integrity": "sha512-HZQYqbiFVWufzCwexrvh694SOim8z2d+xJl5UNamcvQFejLY/2YUtzXHYi3cHdI7PMlS8ejH2slRAOJQ32aNbA==",
+            "dev": true,
+            "peer": true
+        },
+        "node_modules/@types/markdown-it": {
+            "version": "12.2.3",
+            "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-12.2.3.tgz",
+            "integrity": "sha512-GKMHFfv3458yYy+v/N8gjufHO6MSZKCOXpZc5GXIWWy8uldwfmPn98vp81gZ5f9SVw8YYBctgfJ22a2d7AOMeQ==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "@types/linkify-it": "*",
+                "@types/mdurl": "*"
+            }
+        },
+        "node_modules/@types/mdurl": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.2.tgz",
+            "integrity": "sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA==",
+            "dev": true,
+            "peer": true
         },
         "node_modules/@types/minimatch": {
             "version": "3.0.4",
@@ -768,6 +808,12 @@
             "version": "0.0.5",
             "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.5.tgz",
             "integrity": "sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig==",
+            "dev": true
+        },
+        "node_modules/boolbase": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+            "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
             "dev": true
         },
         "node_modules/boxen": {
@@ -1419,11 +1465,39 @@
                 "node": "*"
             }
         },
+        "node_modules/css-select": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
+            "integrity": "sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==",
+            "dev": true,
+            "dependencies": {
+                "boolbase": "^1.0.0",
+                "css-what": "^6.0.1",
+                "domhandler": "^4.3.1",
+                "domutils": "^2.8.0",
+                "nth-check": "^2.0.1"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/fb55"
+            }
+        },
         "node_modules/css-unit-converter": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/css-unit-converter/-/css-unit-converter-1.1.2.tgz",
             "integrity": "sha512-IiJwMC8rdZE0+xiEZHeru6YoONC4rfPMqGm2W85jMIbkFvv5nFTwJVFHam2eFrN6txmoUYFAFXiv8ICVeTO0MA==",
             "dev": true
+        },
+        "node_modules/css-what": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
+            "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
+            "dev": true,
+            "engines": {
+                "node": ">= 6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/fb55"
+            }
         },
         "node_modules/cssesc": {
             "version": "3.0.0",
@@ -1436,6 +1510,12 @@
             "engines": {
                 "node": ">=4"
             }
+        },
+        "node_modules/cssom": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
+            "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
+            "dev": true
         },
         "node_modules/csstype": {
             "version": "2.6.20",
@@ -1657,9 +1737,9 @@
             ]
         },
         "node_modules/domhandler": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.2.tgz",
-            "integrity": "sha512-PzE9aBMsdZO8TK4BnuJwH0QT41wgMbRzuZrHUcpYncEjmQazq8QEaBWgLG7ZyC/DAZKEgglpIA6j4Qn/HmxS3w==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
+            "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
             "dev": true,
             "dependencies": {
                 "domelementtype": "^2.2.0"
@@ -2570,6 +2650,12 @@
             "integrity": "sha1-wc56MWjIxmFAM6S194d/OyJfnDg=",
             "dev": true
         },
+        "node_modules/html-escaper": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
+            "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==",
+            "dev": true
+        },
         "node_modules/html-tags": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.1.0.tgz",
@@ -3399,6 +3485,50 @@
             "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
             "dev": true
         },
+        "node_modules/linkedom": {
+            "version": "0.13.7",
+            "resolved": "https://registry.npmjs.org/linkedom/-/linkedom-0.13.7.tgz",
+            "integrity": "sha512-We9cyPHV/exsrC43KXtItjqSTxwrK9pLpOnG6TLzqXrmqwe/wqd3Gi6eAAU4YCqfTgy79R8g75hY2fS7723XUg==",
+            "dev": true,
+            "dependencies": {
+                "css-select": "^4.2.1",
+                "cssom": "^0.5.0",
+                "html-escaper": "^3.0.3",
+                "htmlparser2": "^7.2.0",
+                "uhyphen": "^0.1.0"
+            }
+        },
+        "node_modules/linkedom/node_modules/entities": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
+            "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.12"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
+        },
+        "node_modules/linkedom/node_modules/htmlparser2": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-7.2.0.tgz",
+            "integrity": "sha512-H7MImA4MS6cw7nbyURtLPO1Tms7C5H602LRETv95z1MxO/7CP7rDVROehUYeYBUYEON94NXXDEPmZuq+hX4sog==",
+            "dev": true,
+            "funding": [
+                "https://github.com/fb55/htmlparser2?sponsor=1",
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fb55"
+                }
+            ],
+            "dependencies": {
+                "domelementtype": "^2.0.1",
+                "domhandler": "^4.2.2",
+                "domutils": "^2.8.0",
+                "entities": "^3.0.1"
+            }
+        },
         "node_modules/linkify-it": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
@@ -4158,6 +4288,18 @@
             },
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/nth-check": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.1.tgz",
+            "integrity": "sha512-it1vE95zF6dTT9lBsYbxvqh0Soy4SPowchj0UBGj/V6cTPnXXtQOPUbhZ6CmGzAD/rW22LQK6E96pcdJXk4A4w==",
+            "dev": true,
+            "dependencies": {
+                "boolbase": "^1.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/nth-check?sponsor=1"
             }
         },
         "node_modules/nunjucks": {
@@ -4972,6 +5114,15 @@
             },
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/prismjs": {
+            "version": "1.28.0",
+            "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.28.0.tgz",
+            "integrity": "sha512-8aaXdYvl1F7iC7Xm1spqSaY/OJBpYW3v+KJ+F17iYxvdc8sfjW194COK5wVhMZX45tGteiBQgdvD/nhxcRwylw==",
+            "dev": true,
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/promise": {
@@ -6645,6 +6796,12 @@
                 "node": ">=0.8.0"
             }
         },
+        "node_modules/uhyphen": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/uhyphen/-/uhyphen-0.1.0.tgz",
+            "integrity": "sha512-o0QVGuFg24FK765Qdd5kk0zU/U4dEsCtN/GSiwNI9i8xsSVtjIAOdTaVhLwZ1nrbWxFVMxNDDl+9fednsOMsBw==",
+            "dev": true
+        },
         "node_modules/unbox-primitive": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
@@ -7193,6 +7350,16 @@
                 "posthtml-urls": "1.0.0"
             }
         },
+        "@11ty/eleventy-plugin-syntaxhighlight": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@11ty/eleventy-plugin-syntaxhighlight/-/eleventy-plugin-syntaxhighlight-4.0.0.tgz",
+            "integrity": "sha512-t95DIZQ7MnaspgpmXyKIgz2TpyN7EshMt9+SFfqVUYKTISU3+T3FTXFscoLownyNWb/5EC0od69BnCZwEcMzCg==",
+            "dev": true,
+            "requires": {
+                "linkedom": "^0.13.2",
+                "prismjs": "^1.26.0"
+            }
+        },
         "@babel/code-frame": {
             "version": "7.15.8",
             "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.15.8.tgz",
@@ -7358,6 +7525,31 @@
                 "lodash.merge": "^4.6.2",
                 "lodash.uniq": "^4.5.0"
             }
+        },
+        "@types/linkify-it": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.2.tgz",
+            "integrity": "sha512-HZQYqbiFVWufzCwexrvh694SOim8z2d+xJl5UNamcvQFejLY/2YUtzXHYi3cHdI7PMlS8ejH2slRAOJQ32aNbA==",
+            "dev": true,
+            "peer": true
+        },
+        "@types/markdown-it": {
+            "version": "12.2.3",
+            "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-12.2.3.tgz",
+            "integrity": "sha512-GKMHFfv3458yYy+v/N8gjufHO6MSZKCOXpZc5GXIWWy8uldwfmPn98vp81gZ5f9SVw8YYBctgfJ22a2d7AOMeQ==",
+            "dev": true,
+            "peer": true,
+            "requires": {
+                "@types/linkify-it": "*",
+                "@types/mdurl": "*"
+            }
+        },
+        "@types/mdurl": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.2.tgz",
+            "integrity": "sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA==",
+            "dev": true,
+            "peer": true
         },
         "@types/minimatch": {
             "version": "3.0.4",
@@ -7711,6 +7903,12 @@
             "version": "0.0.5",
             "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.5.tgz",
             "integrity": "sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig==",
+            "dev": true
+        },
+        "boolbase": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+            "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
             "dev": true
         },
         "boxen": {
@@ -8242,16 +8440,41 @@
             "integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA=",
             "dev": true
         },
+        "css-select": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
+            "integrity": "sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==",
+            "dev": true,
+            "requires": {
+                "boolbase": "^1.0.0",
+                "css-what": "^6.0.1",
+                "domhandler": "^4.3.1",
+                "domutils": "^2.8.0",
+                "nth-check": "^2.0.1"
+            }
+        },
         "css-unit-converter": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/css-unit-converter/-/css-unit-converter-1.1.2.tgz",
             "integrity": "sha512-IiJwMC8rdZE0+xiEZHeru6YoONC4rfPMqGm2W85jMIbkFvv5nFTwJVFHam2eFrN6txmoUYFAFXiv8ICVeTO0MA==",
             "dev": true
         },
+        "css-what": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
+            "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
+            "dev": true
+        },
         "cssesc": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
             "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+            "dev": true
+        },
+        "cssom": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
+            "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
             "dev": true
         },
         "csstype": {
@@ -8420,9 +8643,9 @@
             "dev": true
         },
         "domhandler": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.2.tgz",
-            "integrity": "sha512-PzE9aBMsdZO8TK4BnuJwH0QT41wgMbRzuZrHUcpYncEjmQazq8QEaBWgLG7ZyC/DAZKEgglpIA6j4Qn/HmxS3w==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
+            "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
             "dev": true,
             "requires": {
                 "domelementtype": "^2.2.0"
@@ -9133,6 +9356,12 @@
             "integrity": "sha1-wc56MWjIxmFAM6S194d/OyJfnDg=",
             "dev": true
         },
+        "html-escaper": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
+            "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==",
+            "dev": true
+        },
         "html-tags": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.1.0.tgz",
@@ -9762,6 +9991,39 @@
             "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
             "dev": true
         },
+        "linkedom": {
+            "version": "0.13.7",
+            "resolved": "https://registry.npmjs.org/linkedom/-/linkedom-0.13.7.tgz",
+            "integrity": "sha512-We9cyPHV/exsrC43KXtItjqSTxwrK9pLpOnG6TLzqXrmqwe/wqd3Gi6eAAU4YCqfTgy79R8g75hY2fS7723XUg==",
+            "dev": true,
+            "requires": {
+                "css-select": "^4.2.1",
+                "cssom": "^0.5.0",
+                "html-escaper": "^3.0.3",
+                "htmlparser2": "^7.2.0",
+                "uhyphen": "^0.1.0"
+            },
+            "dependencies": {
+                "entities": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
+                    "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
+                    "dev": true
+                },
+                "htmlparser2": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-7.2.0.tgz",
+                    "integrity": "sha512-H7MImA4MS6cw7nbyURtLPO1Tms7C5H602LRETv95z1MxO/7CP7rDVROehUYeYBUYEON94NXXDEPmZuq+hX4sog==",
+                    "dev": true,
+                    "requires": {
+                        "domelementtype": "^2.0.1",
+                        "domhandler": "^4.2.2",
+                        "domutils": "^2.8.0",
+                        "entities": "^3.0.1"
+                    }
+                }
+            }
+        },
         "linkify-it": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
@@ -10365,6 +10627,15 @@
                 }
             }
         },
+        "nth-check": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.1.tgz",
+            "integrity": "sha512-it1vE95zF6dTT9lBsYbxvqh0Soy4SPowchj0UBGj/V6cTPnXXtQOPUbhZ6CmGzAD/rW22LQK6E96pcdJXk4A4w==",
+            "dev": true,
+            "requires": {
+                "boolbase": "^1.0.0"
+            }
+        },
         "nunjucks": {
             "version": "3.2.3",
             "resolved": "https://registry.npmjs.org/nunjucks/-/nunjucks-3.2.3.tgz",
@@ -10935,6 +11206,12 @@
             "requires": {
                 "parse-ms": "^0.1.0"
             }
+        },
+        "prismjs": {
+            "version": "1.28.0",
+            "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.28.0.tgz",
+            "integrity": "sha512-8aaXdYvl1F7iC7Xm1spqSaY/OJBpYW3v+KJ+F17iYxvdc8sfjW194COK5wVhMZX45tGteiBQgdvD/nhxcRwylw==",
+            "dev": true
         },
         "promise": {
             "version": "7.3.1",
@@ -12320,6 +12597,12 @@
             "integrity": "sha512-SbMu4D2Vo95LMC/MetNaso1194M1htEA+JrqE9Hk+G2DhI+itfS9TRu9ZKeCahLDNa/J3n4MqUJ/fOHMzQpRWw==",
             "dev": true,
             "optional": true
+        },
+        "uhyphen": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/uhyphen/-/uhyphen-0.1.0.tgz",
+            "integrity": "sha512-o0QVGuFg24FK765Qdd5kk0zU/U4dEsCtN/GSiwNI9i8xsSVtjIAOdTaVhLwZ1nrbWxFVMxNDDl+9fednsOMsBw==",
+            "dev": true
         },
         "unbox-primitive": {
             "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "devDependencies": {
         "@11ty/eleventy": "^0.12.1",
         "@11ty/eleventy-plugin-rss": "^1.1.2",
+        "@11ty/eleventy-plugin-syntaxhighlight": "^4.0.0",
         "@tailwindcss/typography": "^0.4.1",
         "markdown-it-anchor": "^8.4.1",
         "nodemon": "^2.0.15",


### PR DESCRIPTION
Before this change code-blocks, started with triple backticks, didn't
work and broke the rendering of the rest of the page. This change fixes
the rendering of these.

Validated these changes by comparing rendering of the docs locally
versus on the deployed website.

An example of where it currently goes wrong: https://flowforge.com/docs/admin/telemetry/