### PR TITLE
Remove CTAs for the waitlist

### DIFF
--- a/src/blog/2022/02/announcing-flowforge-cloud.md
+++ b/src/blog/2022/02/announcing-flowforge-cloud.md
@@ -20,23 +20,6 @@ Node-RED as a service offering and today we are opening the waitlist.
  
 Our waitlist captures your email, and we'll reach out to you on that address once your account is created.
 
-#### Joining the wait list
-
-<div class="mt-4 flex flex-col">
-    <form
-        action="https://buttondown.email/api/emails/embed-subscribe/flowforge-waitlist"
-        method="post"
-        target="popupwindow"
-        onsubmit="window.open('https://buttondown.email/flowforge-waitlist', 'popupwindow')"
-        class="embeddable-buttondown-form p-1 my-1 ">
-    <div class="flex flex-col md:flex-row">
-        <input type="email" name="email" id="bd-email" placeholder="Enter your email" class="lg:w-80 md:w-60 py-2 px-4 rounded border-blue-hero border-2 focus:border-blue-hero-darker  focus:outline-none" />
-        <input type="hidden" value="1" name="embed" />
-        <input type="submit" value="Sign Up" class="ff-btn ff-btn--secondary cursor-pointer mt-2 md:mt-0 md:ml-3 py-2 px-4 text-white font-semibold rounded bg-blue-hero border-2 border-blue-hero hover:bg-blue-hero-darker hover:border-blue-hero-darker"/>
-    </div>
-</form>
-</div>
-
 ### Starting operations
 
 After having released v0.2 recently, we're now working on v0.3 that will include

--- a/src/blog/2022/03/flowforge-03-released.md
+++ b/src/blog/2022/03/flowforge-03-released.md
@@ -100,24 +100,6 @@ Our regular release cycle puts the next release on Thursday 14th April.
 We're still in planning stage for the release, but we'll also be beginning to invite
 people from the waiting list to sign-up to FlowForge Cloud.
 
-For more information, check out the [annoucement blog post](https://flowforge.com/blog/announcing-flowforge-cloud/), or join the waiting
-list here:
-
-<div class="mt-4 flex flex-col">
-    <form
-        action="https://buttondown.email/api/emails/embed-subscribe/flowforge-waitlist"
-        method="post"
-        target="popupwindow"
-        onsubmit="window.open('https://buttondown.email/flowforge-waitlist', 'popupwindow')"
-        class="embeddable-buttondown-form p-1 my-1 ">
-    <div class="flex flex-col md:flex-row">
-        <input type="email" name="email" id="bd-email" placeholder="Enter your email" class="lg:w-80 md:w-60 py-2 px-4 rounded border-blue-hero border-2 focus:border-blue-hero-darker  focus:outline-none" />
-        <input type="hidden" value="1" name="embed" />
-        <input type="submit" value="Sign Up" class="ff-btn ff-btn--secondary cursor-pointer mt-2 md:mt-0 md:ml-3 py-2 px-4 text-white font-semibold rounded bg-blue-hero border-2 border-blue-hero hover:bg-blue-hero-darker hover:border-blue-hero-darker"/>
-    </div>
-</form>
-</div>
-
-
+For more information, check out the [annoucement blog post](https://flowforge.com/blog/announcing-flowforge-cloud/).
 You can also sign up to our general mailing list below if you want to hear more
 about the work we're doing.

--- a/src/blog/2022/04/flowforge-04-released.md
+++ b/src/blog/2022/04/flowforge-04-released.md
@@ -71,27 +71,7 @@ We also have a `#flowforge` channel on the [Node-RED Slack workspace](https://no
 Our regular release cycle puts the next release on Thursday 12th May.
 We will be building on features in the last few releases around managing your projects and using templates, we're also  setting the foundations of our work to [manage Node-RED on your own devices running at the Edge](https://github.com/flowforge/flowforge/issues/446).
 
-
-Our first users have already been creating projects on FlowForge, you can too if you enter your email below to join the waitlist.
-
-For more information, check out the [announcement blog post](https://flowforge.com/blog/announcing-flowforge-cloud/), or join the waiting
-list here:
-
-<div class="mt-4 flex flex-col">
-    <form
-        action="https://buttondown.email/api/emails/embed-subscribe/flowforge-waitlist"
-        method="post"
-        target="popupwindow"
-        onsubmit="window.open('https://buttondown.email/flowforge-waitlist', 'popupwindow')"
-        class="embeddable-buttondown-form p-1 my-1 ">
-    <div class="flex flex-col md:flex-row">
-        <input type="email" name="email" id="bd-email" placeholder="Enter your email" class="lg:w-80 md:w-60 py-2 px-4 rounded border-blue-hero border-2 focus:border-blue-hero-darker  focus:outline-none" />
-        <input type="hidden" value="1" name="embed" />
-        <input type="submit" value="Sign Up" class="ff-btn ff-btn--secondary cursor-pointer mt-2 md:mt-0 md:ml-3 py-2 px-4 text-white font-semibold rounded bg-blue-hero border-2 border-blue-hero hover:bg-blue-hero-darker hover:border-blue-hero-darker"/>
-    </div>
-</form>
-</div>
-
+For more information, check out the [announcement blog post](https://flowforge.com/blog/announcing-flowforge-cloud/).
 
 You can also sign up to our general mailing list below if you want to hear more
 about the work we're doing.

--- a/src/blog/2022/04/flowforge-accepting-customers.md
+++ b/src/blog/2022/04/flowforge-accepting-customers.md
@@ -31,21 +31,3 @@ access to the same flows and can collaborate. Further, once Node-RED 3.0 has
 been released, the platform will provide a pain-free way to upgrade and keep
 your projects up to date. There's many more exciting features right around the
 corner on our [roadmap](https://github.com/orgs/flowforge/projects/5).
-
-#### Joining the wait list
-
-<div class="mt-4 flex flex-col">
-    <form
-        action="https://buttondown.email/api/emails/embed-subscribe/flowforge-waitlist"
-        method="post"
-        target="popupwindow"
-        onsubmit="window.open('https://buttondown.email/flowforge-waitlist', 'popupwindow')"
-        class="embeddable-buttondown-form p-1 my-1 ">
-    <div class="flex flex-col md:flex-row">
-        <input type="email" name="email" id="bd-email" placeholder="Enter your email" class="lg:w-80 md:w-60 py-2 px-4 rounded border-blue-hero border-2 focus:border-blue-hero-darker  focus:outline-none" />
-        <input type="hidden" value="1" name="embed" />
-        <input type="submit" value="Sign Up" class="ff-btn ff-btn--secondary ml-4"/>
-    </div>
-</form>
-</div>
-

--- a/src/blog/2022/05/flowforge-05-released.md
+++ b/src/blog/2022/05/flowforge-05-released.md
@@ -87,22 +87,3 @@ raise an [issue on GitHub](https://github.com/flowforge/flowforge/issues).
 That also includes if you have any feedback or feature requests.
 
 We also have a `#flowforge` channel on the [Node-RED Slack workspace](https://nodered.org/slack).
-
-### FlowForge Cloud
-
-If you want to sign-up to FlowForge Cloud you can join the waitlist below.
-
-<div class="mt-4 flex flex-col">
-    <form
-        action="https://buttondown.email/api/emails/embed-subscribe/flowforge-waitlist"
-        method="post"
-        target="popupwindow"
-        onsubmit="window.open('https://buttondown.email/flowforge-waitlist', 'popupwindow')"
-        class="embeddable-buttondown-form p-1 my-1 ">
-    <div class="flex flex-col md:flex-row">
-        <input type="email" name="email" id="bd-email" placeholder="Enter your email" class="lg:w-80 md:w-60 py-2 px-4 rounded border-blue-hero border-2 focus:border-blue-hero-darker  focus:outline-none" />
-        <input type="hidden" value="1" name="embed" />
-        <input type="submit" value="Sign Up" class="ff-btn ff-btn--secondary cursor-pointer mt-2 md:mt-0 md:ml-3 py-2 px-4 text-white font-semibold rounded bg-blue-hero border-2 border-blue-hero hover:bg-blue-hero-darker hover:border-blue-hero-darker"/>
-    </div>
-</form>
-</div>

--- a/src/blog/2022/05/node-red-3-beta-stack.md
+++ b/src/blog/2022/05/node-red-3-beta-stack.md
@@ -21,22 +21,3 @@ Yesterday the first beta of Node-RED 3.0 was [released](https://discourse.nodere
 FlowForge is the best way to run multiple Node-RED instances at different versions. Beta releases are exciting to try out, but you don't want to risk your production applications with an early upgrade. FlowForge makes it easy to create a new project to try things out.
 
 We'll continue to update the stack choice with each beta when they are released.
-
-We're still draining the wait list for FlowForge Cloud, so it's not too late to sign up.
-
-#### Joining the wait list
-
-<div class="mt-4 flex flex-col">
-    <form
-        action="https://buttondown.email/api/emails/embed-subscribe/flowforge-waitlist"
-        method="post"
-        target="popupwindow"
-        onsubmit="window.open('https://buttondown.email/flowforge-waitlist', 'popupwindow')"
-        class="embeddable-buttondown-form p-1 my-1 ">
-    <div class="flex flex-col md:flex-row">
-        <input type="email" name="email" id="bd-email" placeholder="Enter your email" class="lg:w-80 md:w-60 py-2 px-4 rounded border-blue-hero border-2 focus:border-blue-hero-darker  focus:outline-none" />
-        <input type="hidden" value="1" name="embed" />
-        <input type="submit" value="Sign Up" class="ff-btn ff-btn--secondary ml-4"/>
-    </div>
-</form>
-</div>

--- a/src/index.njk
+++ b/src/index.njk
@@ -12,18 +12,8 @@ layout: default
             environment, built around the open-source Node-RED project
         </h3>
         <div class="flex flex-col">
-            <h2 class="text-lg font-medium text-teal-500 mt-8">Join the Waitlist</h2>
-            <form
-                action="https://buttondown.email/api/emails/embed-subscribe/flowforge-waitlist"
-                method="post"
-                target="popupwindow"
-                onsubmit="window.open('https://buttondown.email/flowforge-waitlist', 'popupwindow')"
-                class="embeddable-buttondown-form p-1 my-1 "
-            >
                 <div class="max-w-md m-auto">
-                    <input type="email" name="email" id="bd-email" placeholder="Enter your email" class="ff-input ff-text-input" />
-                    <input type="hidden" value="1" name="embed" />
-                    <input type="submit" value="Sign Up" class="leading-6 m-auto mt-4 ff-btn ff-btn--secondary"/>
+                    <a class="ff-btn ff-btn--primary" href="https://app.flowforge.com/account/create">Sign up</a>
                 </div>
             </form>
         </div> 

--- a/src/index.njk
+++ b/src/index.njk
@@ -12,8 +12,8 @@ layout: default
             environment, built around the open-source Node-RED project
         </h3>
         <div class="flex flex-col">
-                <div class="max-w-md m-auto">
-                    <a class="ff-btn ff-btn--primary" href="https://app.flowforge.com/account/create">Sign up</a>
+                <div class="max-w-md m-auto mt-6">
+                    <a class="ff-btn ff-btn--secondary" href="https://app.flowforge.com/account/create">Sign up</a>
                 </div>
             </form>
         </div> 

--- a/src/pricing.njk
+++ b/src/pricing.njk
@@ -22,7 +22,7 @@ layout: layouts/page.njk
                 <label>/project/mo</label>
             </div>
         </div>
-        <a class="ff-btn ff-btn--primary" href="https://flowforge.com/blog/2022/02/announcing-flowforge-cloud/">Get Started</a>
+        <a class="ff-btn ff-btn--primary" href="https://app.flowforge.com/account/create">Sign up</a>
     </div>
     <div class="pricing-tile">
         <div class="flex justify-between items-center mb-4 px-4 md:-mb-0 md:px-0 md:block">

--- a/src/product.njk
+++ b/src/product.njk
@@ -4,20 +4,7 @@ layout: layouts/page.njk
 subtitle: Team-based Low-Code Development
 description:
     <p>Start building your low-code workflows on FlowForge Cloud with your team.<p>Get started with just a few clicks.</p>
-    <form
-        action="https://buttondown.email/api/emails/embed-subscribe/flowforge-waitlist"
-        method="post"
-        target="popupwindow"
-        onsubmit="window.open('https://buttondown.email/flowforge-waitlist', 'popupwindow')"
-        class="embeddable-buttondown-form p-1 my-1 "
-    >
-        <div class="max-w-md m-auto">
-            <h5 class="mt-4 mb-2">Join the Waitlist</h5>
-            <input type="email" name="email" id="bd-email" placeholder="Enter your email" class="ff-input ff-text-input" />
-            <input type="hidden" value="1" name="embed" />
-            <button type="submit" class='ff-btn ff-btn--secondary mt-4'>Sign Up</button>
-        </div>
-    </form>
+    <a class="ff-btn ff-btn--primary" href="https://app.flowforge.com/account/create">Sign up</a>
 heroimg: "../images/pictograms/cloud.png"
 heroLg: true
 ---

--- a/src/product.njk
+++ b/src/product.njk
@@ -4,7 +4,7 @@ layout: layouts/page.njk
 subtitle: Team-based Low-Code Development
 description:
     <p>Start building your low-code workflows on FlowForge Cloud with your team.<p>Get started with just a few clicks.</p>
-    <a class="ff-btn ff-btn--primary" href="https://app.flowforge.com/account/create">Sign up</a>
+    <a class="ff-btn ff-btn--secondary inline-block" href="https://app.flowforge.com/account/create">Sign up</a>
 heroimg: "../images/pictograms/cloud.png"
 heroLg: true
 ---


### PR DESCRIPTION
As users can directly sign up and the waitlist is phased out, the website needs new CTA's and disallow waitlist sign ups.