### PR TITLE
Ensure docs/handbook links are properly rewritten

### DIFF
--- a/scripts/copy_docs.sh
+++ b/scripts/copy_docs.sh
@@ -27,6 +27,7 @@ do
      case "$file" in
          *.md)
             echo "---" > $destFile
+            echo "originalPath: $file" >> $destFile
             echo "updated: $lastUpdate" >> $destFile
             echo "version: $version" >> $destFile
             echo "---" >> $destFile

--- a/scripts/copy_handbook.sh
+++ b/scripts/copy_handbook.sh
@@ -25,6 +25,7 @@ do
      case "$file" in
          *.md)
             echo "---" > $destFile
+            echo "originalPath: $file" >> $destFile
             echo "updated: $lastUpdate" >> $destFile
             echo "---" >> $destFile
             cat $file >> $destFile

--- a/src/_includes/layouts/handbook.njk
+++ b/src/_includes/layouts/handbook.njk
@@ -13,13 +13,13 @@ layout: nohero
     <div class="w-full mx-auto ff-bg-light flex flex-col md:flex-row">
         <div class="flex-grow order-last md:order-first">
             <div class="mt-6 mb-4 prose prose-blue main-content">
-                {{ content | rewriteHandbookLinks | safe }}
+                {{ content | rewriteHandbookLinks(page) | safe }}
             </div>
         </div>
         <div class="w-full md:w-64 md:ml-8 mt-4 md:mt-6 px-2">
             <h3 class="font-medium border-b pb-1 mb-4">On this page</h3>
             <ul id="toc" class="text-sm border-b mb-4"></ul>
-            <div class="text-sm pb-1 text-right mb-4"><a href="https://github.com/flowforge/handbook/edit/main/{{ page.filePathStem | handbookMapOriginalPath }}">Edit this page</a></div>
+            <div class="text-sm pb-1 text-right mb-4"><a href="{{ page | handbookEditLink(originalPath) }}">Edit this page</a></div>
             <div class="text-xs pb-1 text-right mb-4 italic">Updated: {{ updated }}</div>
         </div>
     </div>


### PR DESCRIPTION
This fixes issues with how we were rewriting urls when pulling in content from the docs and handbook repos.

It ensures that relative links in markdown get handled properly.

It also fixes the 'Edit this page' link in the sidebar so it links to the correct repo (it was hardcoded to link to handbook and not updated when we added docs).