### PR TITLE
pricing: Link to install docs

### DIFF
--- a/src/pricing.njk
+++ b/src/pricing.njk
@@ -12,7 +12,7 @@ layout: layouts/page.njk
                 <label>Apache 2.0 License</label>
             </div>
         </div>
-        <a class="ff-btn ff-btn--secondary" href="https://github.com/flowforge/flowforge">View on GitHub</a>
+        <a class="ff-btn ff-btn--secondary" href="/docs/install">Install now</a>
     </div>
     <div class="pricing-tile">
         <div class="flex justify-between items-center mb-4 px-4 md:-mb-0 md:px-0 md:block">


### PR DESCRIPTION
While linking to the GitHub page is great, the docs on how to install
are probably more relevant. Contributing to FlowForge is only following
after succesfully installing and understanding the value.