### PR TITLE
contact us: Add support email to the page

### DIFF
--- a/src/contact-us.njk
+++ b/src/contact-us.njk
@@ -4,6 +4,7 @@ title: Contact us
 ---
 <div>
   <div class="flex justify-between items-center mb-4 md:px-4 md:-mb-0 md:px-0 md:block">
+    <p>For support queries please email <a href="mailto:support@flowforge.com">support@flowforge.com</a>.</p>
     <div class="ff-bg-light product px-4 pb-24 pt-4 md:pt-12 md:p-12 md:grid grid-cols-2">
       <img class="hidden md:w-72 md:m-auto md:block md:mt-0" src="../images/pictograms/browser_red.png" />
 


### PR DESCRIPTION
As some folks had support questions that ended up in salesforce, let's
add the support email to the contact page to resolve that.