### PR TITLE
add switch for sales/support

### DIFF
--- a/src/contact-us.njk
+++ b/src/contact-us.njk
@@ -4,7 +4,6 @@ title: Contact us
 ---
 <div>
   <div class="flex justify-between items-center mb-4 md:px-4 md:-mb-0 md:px-0 md:block">
-    <p>For support queries please email <a href="mailto:support@flowforge.com">support@flowforge.com</a>.</p>
     <div class="ff-bg-light product px-4 pb-24 pt-4 md:pt-12 md:p-12 md:grid grid-cols-2">
       <img class="hidden md:w-72 md:m-auto md:block md:mt-0" src="../images/pictograms/browser_red.png" />
 
@@ -19,9 +18,21 @@ title: Contact us
           }
         }
         setInterval(timestamp, 500); 
+        function toggleType(){
+          switch (document.getElementById("type").value){
+            case 'sales':
+              document.getElementById("contact-form").action = "https://webto.salesforce.com/servlet/servlet.WebToCase?encoding=UTF-8"
+              document.getElementsByName('submit')[0].style.display = 'block'
+              break;
+            case 'support':
+              document.getElementById("contact-form").action = "https://fftools.flowforge.cloud/contact-support"
+              document.getElementsByName('submit')[0].style.display = 'block'
+              break;
+          }
+        }
       </script>
 
-      <form action="https://webto.salesforce.com/servlet/servlet.WebToCase?encoding=UTF-8" method="POST">
+      <form id="contact-form" action="" method="POST">
         <input type=hidden name='captcha_settings' value='{"keyname":"googlerecaptchav2","fallback":"true","orgId":"00D8a0000028InL","ts":""}'>
         <input type=hidden name="orgid" value="00D8a0000028InL">
         <input type=hidden name="retURL" value="https://flowforge.com/contact-us?submit=true">
@@ -36,9 +47,16 @@ title: Contact us
 
         <label for="description" class="font-medium">Description</label>
         <textarea name="description" class="h-32 w-full border border-grey-300 px-2 py-1 mb-4"></textarea><br>
-
+        
+        <select class="font-medium" id="type" onchange="toggleType()">
+          <option value="" disabled selected>Select topic</option>
+          <option value="sales">Sales Enquiry</option>
+          <option value="support">Support Request</option>
+        </select></br></br>
+        
         <div class="w-full g-recaptcha" data-sitekey="6LdMxjcgAAAAAI2YRWs1lf7DnXfxxaZdUSlI0AUO"></div><br>
-        <input type="submit" name="submit" class="ff-btn ff-btn--primary w-full mt-0">
+    
+        <input type="submit" name="submit" class="ff-btn ff-btn--primary w-full mt-0" style = "display:none">
       </form>
     </div>
   </div>

--- a/src/contact-us.njk
+++ b/src/contact-us.njk
@@ -37,6 +37,13 @@ title: Contact us
         <input type=hidden name="orgid" value="00D8a0000028InL">
         <input type=hidden name="retURL" value="https://flowforge.com/contact-us?submit=true">
 
+        <label for="description" class="font-medium">Topic</label>
+        <select class="ff-input ff-select ff-text-input font-medium" id="type" onchange="toggleType()">
+          <option value="" disabled selected>Select topic</option>
+          <option value="sales">Sales Enquiry</option>
+          <option value="support">Support Request</option>
+        </select></br></br>
+
         <label for="name" class="font-medium">Name</label><input class="ff-input ff-text-input mb-4" id="name" maxlength="80" name="name" size="20" type="text" /><br>
 
         <label for="email" class="font-medium">Email</label><input class="ff-input ff-text-input mb-4" id="email" maxlength="80" name="email" size="20" type="text" /><br>
@@ -47,13 +54,7 @@ title: Contact us
 
         <label for="description" class="font-medium">Description</label>
         <textarea name="description" class="h-32 w-full border border-grey-300 px-2 py-1 mb-4"></textarea><br>
-        
-        <select class="font-medium" id="type" onchange="toggleType()">
-          <option value="" disabled selected>Select topic</option>
-          <option value="sales">Sales Enquiry</option>
-          <option value="support">Support Request</option>
-        </select></br></br>
-        
+                
         <div class="w-full g-recaptcha" data-sitekey="6LdMxjcgAAAAAI2YRWs1lf7DnXfxxaZdUSlI0AUO"></div><br>
     
         <input type="submit" name="submit" class="ff-btn ff-btn--primary w-full mt-0" style = "display:none">

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -232,6 +232,29 @@ h4:hover .header-anchor {
         stroke-width: 2px;
         color: theme(colors.red.600);
     }
+
+    .ff-select {
+        background-color: theme(colors.white);
+        padding: 3px;
+        -webkit-box-sizing: border-box;
+        -moz-box-sizing: border-box;
+        box-sizing: border-box;
+        -webkit-appearance: none;
+        -moz-appearance: none;
+        background-image:
+            linear-gradient(45deg, transparent 50%, gray 50%),
+            linear-gradient(135deg, gray 50%, transparent 50%),
+            linear-gradient(to right, #ccc, #ccc);
+        background-position:
+            calc(100% - 16px) calc(1em + 2px),
+            calc(100% - 11px) calc(1em + 2px),
+            calc(100% - 2.25em) 0.5em;
+        background-size:
+            5px 5px,
+            5px 5px,
+            1px 1.5em;
+        background-repeat: no-repeat;
+    }
     
     .ff-website .ff-video {
         border-radius: 12px;


### PR DESCRIPTION
Adds a new field for customer to select their topic and based on this it then changes the form action between salesforce or a node-red flow (on ff cloud) that routes it to Freshdesk.
The submit button is hidden until the field is selected to make it mandatory