### PR TITLE
Clarify hosting options on pricing table

### DIFF
--- a/src/_includes/feature_lists/cloud.njk
+++ b/src/_includes/feature_lists/cloud.njk
@@ -56,29 +56,23 @@
     }, {
         label: "Setup & Infrastructure",
         rows: [{
+            label: "Hosting",
+            values: ['Self-Hosted', 'FlowForge-Hosted', 'Either']
+        }, {
             label: "Easy Node-RED Upgrades",
             values: ['check', 'check', 'check']
-        }, {
-            label: "Long Term support",
-            values: ['null', 'null', 'check']
-        }, {
-            label: "Sub-Minute Setup",
-            values: [null, 'check', 'check']
-        }, {
-            label: "FlowForge Managed",
-            values: [null, 'check', 'optional']
-        }, {
-            label: "Configurable Infrastructure",
-            values: ['check', null, 'check']
         }]
     }, {
         label: "Support",
         rows: [{
+            label: "Community Support",
+            values: ['check', 'check', 'check']
+        }, {
             label: "Ticket-Based Support",
             values: [null, 'check', 'check']
         }, {
-            label: "Community Support",
-            values: ['check', 'check', 'check']
+            label: "Long Term Support",
+            values: [null, null, 'check']
         }]
     }]
 %}
@@ -113,8 +107,10 @@
                 {% include "components/feature-optional.svg" %}
                 {% elif value === "addon" %}
                 {% include "components/feature-addon.svg" %}
-                {% else %}
+                {% elif value === null %}
                 <span></span>
+                {% else %}
+                {{ value }}
                 {% endif %}
             </span>
             {% endfor %}
@@ -126,13 +122,13 @@
         <li>
             <span></span>
             <span>
-                <a class="ff-btn ff-btn--secondary" href="https://github.com/flowforge/flowforge">View on GitHub</a>
+                <a class="ff-btn ff-btn--secondary" href="/docs/install">Install now</a>
             </span>
             <span>
-                <a class="ff-btn ff-btn--primary" href="https://app.flowforge.com/">Get Started</a>
+                <a class="ff-btn ff-btn--primary" href="https://app.flowforge.com/account/create">Sign up</a>
             </span>
             <span>
-                <a class='ff-btn ff-btn--secondary' href='mailto:sales@flowforge.com?subject=Enquiry - FlowForge Cloud Enterprise'>Contact Us</a>
+                <a class='ff-btn ff-btn--secondary' href='/contact-us'>Contact Us</a>
             </span>
         </li>
     </ul>

--- a/src/_includes/feature_lists/cloud.njk
+++ b/src/_includes/feature_lists/cloud.njk
@@ -57,7 +57,7 @@
         label: "Setup & Infrastructure",
         rows: [{
             label: "Hosting",
-            values: ['Self-Hosted', 'FlowForge-Hosted', 'Either']
+            values: ['Self-Managed', 'FlowForge-Managed', 'Either']
         }, {
             label: "Easy Node-RED Upgrades",
             values: ['check', 'check', 'check']


### PR DESCRIPTION
Closes #159 

This PR makes some changes to the pricing table based on stakeholder feedback.

 - Removed 'Configurable Infrastructure' and 'FlowForge Managed' as it wasn't clear what they meant without additional explanation.
 - Replaced them with a single 'Hosting' row that I think gets the critical point across as to who runs it.
   <img width="974" alt="image" src="https://user-images.githubusercontent.com/51083/188192874-13c77418-fb70-44d0-a40d-d63954d65e96.png">
- Moved the LTS row to the Support Section
- Removed Sub-Minute setup. It wasn't clear if this referring to setting up a new Node-RED instance (in which case it should be in the top section), or setting up the whole platform. Setting up the whole platform is not a sub-minute task.

I also updated the three call to action buttons at the bottom of the page to be consistent with the matching call to action buttons at the top of the page. It is slightly unfortunate how this page has been built meaning these two sets of calls-to-action are defined in two different files so can easily get out of sync. Something to be mindful of.
