### PR TITLE
Consolidate cloud and enterprise columns on pricing page

### DIFF
--- a/src/_includes/feature_lists/cloud.njk
+++ b/src/_includes/feature_lists/cloud.njk
@@ -2,80 +2,74 @@
     set sections = [{
         label: "Features",
         rows: [{
-            label: "Multiple Projects",
-            values: ['check', 'check', 'check']
-        }, {
-            label: "Project Templates",
-            values: ['check', 'check', 'check']
-        }, {
-            label: "Individual Project Configuration",
-            values: ['check', 'check', 'check']
-        }, {
-            label: "Audit Log",
-            values: ['check', 'check', 'check']
-        }, {
-            label: "Team-Based Configuraton",
-            values: ['check', 'check', 'check']
-        }, {
-            label: "Role-Based Access Control",
-            values: ['check', 'check', 'check']
-        }, {
-            label: "Edge Device Management",
-            values: ['check', 'check', 'check']
-        }, {
-            label: "Fully Browser-Based",
-            values: [null, 'check', 'check']
-        }, {
-            label: "Version History",
-            values: ['check', 'check', 'check']
-        }, {
-            label: "Inter Project Communication",
-            values: [null, 'check', 'check']
-        }, {
-            label: "Single Sign-On (SSO)",
-            values: [null, 'time', 'check']
-        }, {
-            label: "Custom Node Catalog",
-            values: [null, 'time', 'time']
-        }, {
-            label: "Shared Team Library",
-            values: [null, 'time', 'time']
-        }, {
-            label: "Persistent Context Storage",
-            values: [null, 'time', 'time']
-        }, {
-            label: "Private npm Repo Support",
-            values: [null, 'time', 'time']
-        }, {
-            label: "Git Integration",
-            values: [null, 'time', 'time']
-        }, {
-            label: "Devops Workflow",
-            values: [null, 'time', 'time']
-        }, {
-            label: "Usage Reporting",
-            values: [null, 'time', 'time']
-	}]
-    }, {
-        label: "Setup & Infrastructure",
-        rows: [{
             label: "Hosting",
-            values: ['Self-Managed', 'FlowForge-Managed', 'Either']
+            values: ['Self-Hosted', 'FlowForge Managed or Self-Hosted']
+        }, {
+            label: "Multiple Projects",
+            values: ['check', 'check']
         }, {
             label: "Easy Node-RED Upgrades",
-            values: ['check', 'check', 'check']
-        }]
+            values: ['check', 'check']
+        }, {
+            label: "Project Templates",
+            values: ['check', 'check']
+        }, {
+            label: "Individual Project Configuration",
+            values: ['check', 'check']
+        }, {
+            label: "Audit Log",
+            values: ['check', 'check']
+        }, {
+            label: "Team-Based Configuraton",
+            values: ['check', 'check']
+        }, {
+            label: "Role-Based Access Control",
+            values: ['check', 'check']
+        }, {
+            label: "Edge Device Management",
+            values: ['check', 'check']
+        }, {
+            label: "Version History",
+            values: ['check', 'check']
+        }, {
+            label: "Inter Project Communication",
+            values: [null, 'check']
+        }, {
+            label: "Single Sign-On (SSO)",
+            values: [null, 'time']
+        }, {
+            label: "Custom Node Catalog",
+            values: [null, 'time']
+        }, {
+            label: "Shared Team Library",
+            values: [null, 'time']
+        }, {
+            label: "Persistent Context Storage",
+            values: [null, 'time']
+        }, {
+            label: "Private npm Repo Support",
+            values: [null, 'time']
+        }, {
+            label: "Git Integration",
+            values: [null, 'time']
+        }, {
+            label: "Devops Workflow",
+            values: [null, 'time']
+        }, {
+            label: "Usage Reporting",
+            values: [null, 'time']
+	}]
     }, {
         label: "Support",
         rows: [{
             label: "Community Support",
-            values: ['check', 'check', 'check']
+            values: ['check', 'check']
         }, {
             label: "Ticket-Based Support",
-            values: [null, 'check', 'check']
+            values: [null, 'check']
         }, {
             label: "Long Term Support",
-            values: [null, null, 'check']
+            values: [null, 'check']
         }]
     }]
 %}
@@ -91,8 +85,7 @@
         <li class="ff-feature--column-header">
             <span></span>
             <label>Community</label>
-            <label>Cloud</label>
-            <label>Enterprise</label>
+            <label>Premium</label>
         </li>
         <li class="ff-feature--header">
             {{ section.label }}
@@ -121,20 +114,6 @@
         {% endfor %}
     </ul>
     {% endfor %}
-    <ul class="ff-feature-table-section">
-        <li>
-            <span></span>
-            <span>
-                <a class="ff-btn ff-btn--secondary" href="/docs/install">Install now</a>
-            </span>
-            <span>
-                <a class="ff-btn ff-btn--primary" href="https://app.flowforge.com/account/create">Sign up</a>
-            </span>
-            <span>
-                <a class='ff-btn ff-btn--secondary' href='/contact-us'>Contact Us</a>
-            </span>
-        </li>
-    </ul>
     <ul class="ff-features-key">
         <li>
             {% include "components/feature-check.svg" %}
@@ -144,9 +123,6 @@
             {% include "components/feature-time.svg" %}
             <label>On the Roadmap</label>
         </li>
-        <li>
-            {% include "components/feature-optional.svg" %}
-            <label>Optional</label>
-        </li>
+        
     </ul>
 </div>

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -377,7 +377,7 @@ h4:hover .header-anchor {
     .ff-feature-table-section li {
         padding: 12px 24px;
         display: grid;
-        grid-template-columns: 250px 1fr 1fr 1fr;
+        grid-template-columns: 250px 1fr 1fr;
         align-items: center;
     }
 

--- a/src/css/style.page.css
+++ b/src/css/style.page.css
@@ -98,7 +98,7 @@
         gap: 48px;
         z-index: 2;
         margin: auto;
-        @apply -mt-32 md:-mt-24 max-w-3xl md:grid-cols-3;
+        @apply -mt-32 md:-mt-24 max-w-2xl md:grid-cols-2;
     }
     .pricing-tile {
         position: relative;

--- a/src/pricing.njk
+++ b/src/pricing.njk
@@ -6,37 +6,29 @@ layout: layouts/page.njk
 <div class="pricing-tiles mb-16">
     <div class="pricing-tile">
         <div class="flex justify-between items-center mb-4 px-4 md:-mb-0 md:px-0 md:block">
-            <h4>Community<br>Edition</h4>
+            <h4>Community</h4>
             <div>
                 <label class="top-label"></label>
                 <h2>$0</h2>
-                <label class="sub-label">Apache 2.0 License</label>
+                <label class="sub-label">&nbsp;</label>
             </div>
         </div>
+        <label class="top-label mb-1">Apache 2.0 License</label>
         <a class="ff-btn ff-btn--secondary" href="/docs/install">Install now</a>
     </div>
     <div class="pricing-tile">
         <div class="flex justify-between items-center mb-4 px-4 md:-mb-0 md:px-0 md:block">
-            <h4>Cloud<br>Edition</h4>
+            <h4>Premium</h4>
             <div>
                 <label class="top-label">from</label>
                 <h2>$15</h2>
                 <label class="sub-label">/project/mo</label>
             </div>
         </div>
+        <label class="top-label mb-1">FlowForge Managed</label>
         <a class="ff-btn ff-btn--primary" href="https://app.flowforge.com/account/create">Sign up</a>
-    </div>
-    <div class="pricing-tile">
-        <div class="flex justify-between items-center mb-4 px-4 md:-mb-0 md:px-0 md:block">
-            <h4>Enterprise<br>Edition</h4>
-            <div class="mb-0">
-                <label class="top-label">from</label>
-                <h2>$25</h2>
-                <label class="sub-label">/project/mo*</label>
-            </div>
-        </div>
+        <label class="top-label mt-4 mb-1">Self-Hosted</label>
         <a class='ff-btn ff-btn--secondary' href='/contact-us'>Contact Us</a>
-        <label class="absolute bottom-0 left-0 pb-4 px-3 w-full text-xs text-gray-400 m-auto block text-center mt-6 italic">* Billed Annually</label>
     </div>
 </div>
 


### PR DESCRIPTION
Closes #175 

This PR reduces the cloud and enterprise columns on the pricing page to a single 'premium' column.

First iteration is proving a bit tricky to get the terminology right and what call-to-actions we want.

The existing CTAs are:

 - Community -> install docs
 - Cloud -> signup to our hosted instance
 - Enterprise -> contact us

Reducing that to two means we need to decide how to present the CTAs for sign-up and contact us. GitLab manage that by having a pop-up modal. I've tried to avoid that with this iteration.

<img width="733" alt="image" src="https://user-images.githubusercontent.com/51083/192315522-2bbf4fc6-9f9f-4177-a6f1-3b4595c20667.png">

Not sure about the name 'Premium' - we need to agree a name here. Less keen to keep iterating it, rather than try to settle on the right thing now.

I've moved the 'hosting' row to the top of the feature table:

<img width="1002" alt="image" src="https://user-images.githubusercontent.com/51083/192318322-07834495-8846-4e7c-8e37-8888cbc6ec27.png">


This PR does *not* touch the Product page yet - that is still using the FlowForge Cloud terminology. That needs reworking before we merge this PR otherwise we have inconsistent pages. I'm getting this PR raised now to enable discussion on whether we think this rework meets the aims of simplifying the page.

