### PR TITLE
product: Replace self-hosted for self-managed

### DIFF
--- a/src/_includes/feature_lists/cloud.njk
+++ b/src/_includes/feature_lists/cloud.njk
@@ -3,7 +3,7 @@
         label: "Features",
         rows: [{
             label: "Hosting",
-            values: ['Self-Hosted', 'FlowForge Managed or Self-Hosted']
+            values: ['Self Managed', 'FlowForge- or Self Managed']
         }, {
             label: "Multiple Projects",
             values: ['check', 'check']

--- a/src/pricing.njk
+++ b/src/pricing.njk
@@ -27,7 +27,7 @@ layout: layouts/page.njk
         </div>
         <label class="top-label mb-1">FlowForge Managed</label>
         <a class="ff-btn ff-btn--primary" href="https://app.flowforge.com/account/create">Sign up</a>
-        <label class="top-label mt-4 mb-1">Self-Hosted</label>
+        <label class="top-label mt-4 mb-1">Self Managed</label>
         <a class='ff-btn ff-btn--secondary' href='/contact-us'>Contact Us</a>
     </div>
 </div>


### PR DESCRIPTION
Reading the pricing and product pages I noticed we were using different terms to communicate FlowForge Inc manages the instance. Which led me to conclude that hardly anyone these days actually self hosts, most installs are going to end up in "the cloud".

As such I think the term "self managed" is more accurate than "self hosted" as it covers more cases.