### PR TITLE
pricing: List Community limits

### DIFF
--- a/src/_includes/feature_lists/cloud.njk
+++ b/src/_includes/feature_lists/cloud.njk
@@ -35,6 +35,15 @@
             label: "Inter Project Communication",
             values: [null, 'check']
         }, {
+            label: "Maximum Teams",
+            values: [50, "Unlimited"]
+        }, {
+            label: "Maximum Projects",
+            values: [50, "Unlimited"]
+        }, {
+            label: "Maximum Devices",
+            values: [50, "Unlimited"]
+        }, {
             label: "Single Sign-On (SSO)",
             values: [null, 'time']
         }, {


### PR DESCRIPTION
The premium and community editions differ in limits for the administrator too. CE is limited by 150 users, 50 teams, 50 projects, and 50 devices.

As users are implicitly limited by team, and max team sizes, I chose not to list those.