### PR TITLE
Subtle H1 messaging change

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -20,8 +20,8 @@ html, body {
     Standard FlowForge Sizings
 */
 h1 {
-    font-size: 2.625rem;
-    line-height: 3.75rem;
+    font-size: 2.25rem;
+    line-height: 3rem;
 }
 
 h2 {

--- a/src/index.njk
+++ b/src/index.njk
@@ -4,7 +4,7 @@ layout: default
 <!--Hero Content-->
 <div class="w-full px-6 pb-24 mt-12 md:px-0">
     <div class="container m-auto text-center max-w-2xl">
-        <h1 class="text-4xl text-gray-50 max-w-lg m-auto">
+        <h1 class="text-gray-50 max-w-lg m-auto">
             Collaborative, <span class="text-teal-500">low code</span> for integration and automation.
         </h1>
         <h3 class="mt-8 text-gray-400 text-lg font-normal">

--- a/src/index.njk
+++ b/src/index.njk
@@ -5,7 +5,7 @@ layout: default
 <div class="w-full px-6 pb-24 mt-12 md:px-0">
     <div class="container m-auto text-center max-w-2xl">
         <h1 class="text-4xl text-gray-50 max-w-lg m-auto">
-            Collaborative, <span class="text-teal-500">low code</span> integration and automation.
+            Collaborative, <span class="text-teal-500">low code</span> for integration and automation.
         </h1>
         <h3 class="mt-8 text-gray-400 text-lg font-normal">
             Combine applications, devices, and data in a secure, scalable, and team-based


### PR DESCRIPTION
before:
<img width="1071" alt="Screenshot 2022-10-16 at 17 52 40" src="https://user-images.githubusercontent.com/99246719/196047926-882ca989-a766-4216-9627-497e8c519828.png">


after:
<img width="1117" alt="Screenshot 2022-10-16 at 17 58 51" src="https://user-images.githubusercontent.com/99246719/196048210-8163db23-ee11-4fc6-924d-bfd17857dfb8.png">

Think this is more natural English and reads cleaner, and the increased line height is easier on the eye.