### PR TITLE
Clearer CTAs on Homepage

### DIFF
--- a/src/index.njk
+++ b/src/index.njk
@@ -13,8 +13,8 @@ layout: default
         </h3>
         <div class="flex flex-col">
           <div class="max-w-md m-auto mt-6 flex flex-row justify-center space-x-4">
-            <a class="ff-btn ff-btn--primary" href="https://app.flowforge.com/account/create">Sign up</a>
-            <a class="ff-btn ff-btn--secondary" href="./docs/install">Install</a>
+            <a class="ff-btn ff-btn--secondary" href="./docs/install">Install Community Edition</a>
+            <a class="ff-btn ff-btn--primary" href="https://app.flowforge.com/account/create">Join FlowForge Cloud</a>
           </div>
         </div> 
     </div>  

--- a/src/index.njk
+++ b/src/index.njk
@@ -12,9 +12,9 @@ layout: default
             environment, built around the open-source Node-RED project
         </h3>
         <div class="flex flex-col">
-          <div class="max-w-md m-auto mt-6 flex flex-row justify-center space-x-4">
-            <a class="ff-btn ff-btn--secondary" href="./docs/install">Install Community Edition</a>
-            <a class="ff-btn ff-btn--primary" href="https://app.flowforge.com/account/create">Join FlowForge Cloud</a>
+          <div class="m-auto mt-6 flex flex-row justify-center space-x-4">
+            <a class="ff-btn ff-btn--secondary" href="./docs/install">Install on your own infrastructure</a>
+            <a class="ff-btn ff-btn--primary" href="https://app.flowforge.com/account/create">Join our managed service</a>
           </div>
         </div> 
     </div>  

--- a/src/product/index.njk
+++ b/src/product/index.njk
@@ -4,7 +4,7 @@ layout: layouts/page.njk
 subtitle: Get started with FlowForge today. Run it for yourself, or sign-up to our managed service.
 description:
     <div class="space-y-4 flex flex-col">
-        <a class="ff-btn ff-btn--primary max-w-xs" href="https://app.flowforge.com/account/create">Sign up to our managed service</a>
+        <a class="ff-btn ff-btn--primary max-w-xs" href="https://app.flowforge.com/account/create">Join our managed service</a>
         <a class="ff-btn ff-btn--secondary max-w-xs" href="/docs/install">Install on your own infrastructure</a>
     </div>
 heroimg: "../images/pictograms/cloud.png"


### PR DESCRIPTION
Closes #199 

**Before:**

<img width="1076" alt="Screenshot 2022-10-16 at 17 44 56" src="https://user-images.githubusercontent.com/99246719/196047581-81bda264-c4e1-410f-aea2-eb3a56942eb2.png">

**After:**

<img width="1909" alt="Screenshot 2022-10-16 at 17 46 11" src="https://user-images.githubusercontent.com/99246719/196047629-4999013a-40c6-41d3-8c17-6bc95240c459.png">