### PR TITLE
Temporarily hide "Product" page

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -45,7 +45,7 @@
                     </div>
 
                     <ul id="nav-content" class="hidden absolute top-8 right-0 border shadow-sm sm:inline sm:shadow-none w-36 z-10 sm:border-0 bg-white sm:bg-transparent sm:w-auto rounded sm:static sm:float-none sm:flex sm:flex-row flex-col items-center justify-between font-medium text no-underline">
-			<li class="flex"><a class="flex-grow sm:px-4 sm:pl-0 sm:py-2" href="/product">product</a></li>
+			            {# <li class="flex"><a class="flex-grow sm:px-4 sm:pl-0 sm:py-2" href="/product">product</a></li> #}
                         <li class="flex"><a href="/pricing">pricing</a></li>
                         <li class="flex"><a href="/blog">news</a></li>
                         <li class="flex"><a href="/docs">docs</a></li>


### PR DESCRIPTION
Realise this may be a contentious decision, btu I would like to _temporarily_ hide the "Product" page as an option for navigation.

PostHog is showing us that we've had no bites on CTAs on that page, and it needs a considerable re-design given the updates to the Homepage and Pricing, that, whilst I can probably get done by 1.0, I do not want to 100% commit to, and i do not want misleading content on there that isn't necessarily adding value at this stage.

https://github.com/flowforge/website/issues/210 will contain the redesign work, and my thoughts on what the Product page should become.
