### PR TITLE
Add improved header styling

### DIFF
--- a/src/css/style.nohero.css
+++ b/src/css/style.nohero.css
@@ -63,3 +63,27 @@
 .prose code::before {
     content:''
 }
+
+.handbook .prose h2 {
+    font-size: 1.75rem;
+}
+
+.handbook .prose h3 {
+    font-size: 1.5rem;
+    /* text-decoration: underline;  */
+}
+
+.handbook .prose h4 {
+    font-size: 1.25rem;
+    color: red;
+}
+
+.handbook .prose h5 {
+    font-size: 1rem;
+    color: red;
+}
+
+.handbook .prose p {
+    margin-top: 0;
+    margin-bottom: 1rem;
+}

--- a/src/css/style.nohero.css
+++ b/src/css/style.nohero.css
@@ -70,17 +70,14 @@
 
 .handbook .prose h3 {
     font-size: 1.5rem;
-    /* text-decoration: underline;  */
 }
 
 .handbook .prose h4 {
     font-size: 1.25rem;
-    color: red;
 }
 
 .handbook .prose h5 {
     font-size: 1rem;
-    color: red;
 }
 
 .handbook .prose p {


### PR DESCRIPTION
Issue caused because Tailwind `.prose` only defines 4-levels of `<hX>` styling. Closes #214 

**Before:**
<img width="706" alt="Screenshot 2022-10-22 at 16 31 13" src="https://user-images.githubusercontent.com/99246719/197348465-99481572-a05e-42d7-a1e0-c7c52b6de415.png">

**After:**
<img width="688" alt="Screenshot 2022-10-22 at 16 30 35" src="https://user-images.githubusercontent.com/99246719/197348463-a079987d-baa7-4cad-a4d2-67b727b83eb9.png">
