### PR TITLE
Updating "hosting" section to "Start using FF" on NR page

### DIFF
--- a/src/node-red.njk
+++ b/src/node-red.njk
@@ -101,31 +101,26 @@ heroLg: true
 {% include "components/divider-flow--top-grey.njk" %}
 
 <!-- Deployment Options -->
-<div class="w-full ff-bg-mid px-6 pt-12 pb-48 md:pt-12 md:px-0">
+<div class="w-full ff-bg-mid px-6 pt-0 pb-32 md:pt-0 md:px-0">
     <div class="container m-auto text-center max-w-4xl">
-        <div class="m-auto mt-3 w-full text-center">
-            <h1>Flexible Hosting Options</h1>
-            <h5 class="text-white font-light">For a full feature comparison, please visit our <a href="/pricing">Pricing</a> page.</h5>
+        <div class="m-auto pt-16 w-full text-center">
+            <h1>Start using FlowForge</h1>
+            <span class="text-white font-light">For a full feature comparison, please visit our <a href="/pricing">Pricing</a> page.</span>
         </div>
-        <div class="sm:mt-10 md:mt-16 w-full max-w-4xl text-center flex flex-wrap gap-2 justify-around">
+        <div class="sm:mt-10 md:mt-10 w-full max-w-4xl text-center flex flex-wrap gap-2 justify-around">
             <div class="w-full px-3 mt-4 sm:w-72 md:mt-0 css-full">
                 <img class="w-40 m-auto mb-4" src="/images/pictograms/opensource.png"/>
                 <h5 class="flex justify-center">Open Source</h5>
-                <label class="text-white mt-2 block">We are an Open Core company. Feel free to try out Flowforge on your own, for free.</label>
-                <label class="text-white mt-2 block">Available on <a href="https://github.com/flowforge/flowforge" target="_blank">GitHub</a></label>
-            </div>
-            <div class="w-full px-3 mt-4 sm:w-72 md:mt-0">
-                <img class="w-40 m-auto mb-4" src="/images/pictograms/cloud.png"/>
-                <h5 class="flex justify-center">FlowForge Managed</h5>
-                <label class="text-white mt-2 block">Get started in less than a minute, fully managed, fully secure.</label>
-                <label class="text-white mt-2 block">Sign up <a href="https://app.flowforge.com/account/create">here</a></label>
+                <label class="text-white mt-2 block">Try for free with deployment options including Docker and K8s.</label>
+                <a class="mt-4 ff-btn ff-btn--secondary inline-block" href="./docs/install">Install</a>
             </div>
             <div class="w-full px-3 mt-4 sm:w-72 md:mt-0">
                 <img class="w-40 m-auto mb-4" src="/images/pictograms/enterprise.png"/>
-                <h5 class="flex justify-center">Self Managed</h5>
-                <label class="text-white mt-2 block">Dedicated instances, additional support and enterprise scale</label>
-                <label class="text-white mt-2 block">Contact us <a href="/contact-us">here</a>.</label>
+                <h5 class="flex justify-center">FlowForge Managed</h5>
+                <label class="text-white mt-2 block">Get started in less than a minute, fully managed, fully secure.</label>
+                <a class="mt-4 ff-btn ff-btn--primary inline-block" href="https://app.flowforge.com/account/create">Join Now</a>
             </div>
         </div>
     </div>
 </div>
+


### PR DESCRIPTION
Update the "Hosting Options" section that I'd put in the "What is Node-RED" page (originally copied from homepage). We removed this section in https://github.com/flowforge/website/pull/212 and so this does the same here.