### PR TITLE
Revert "jobs: Redirect /jobs to Greenhouse board"

### DIFF
--- a/src/redirect.md
+++ b/src/redirect.md
@@ -22,7 +22,6 @@ redirects:
   - { "from": "/blog/announcing-flowforge-cloud/", "to": "/blog/2022/02/announcing-flowforge-cloud/" }
   - { "from": "/blog/community-news-02/", "to": "/blog/2022/03/community-news-02/" }
   - { "from": "/blog/flowforge-03-released/", "to": "/blog/2022/03/flowforge-03-released/" }
-  - { "from": "/jobs", "to": "https://boards.greenhouse.io/flowforge" }
 # The "permalink" attribute determines where the output page will be located.
 permalink: "{{ redirect.from }}"
 # The "redirect" layout just has a small html header with the meta tags that do redirection.


### PR DESCRIPTION
Reverts flowforge/website#229

The redirect didn't work, so I'm just using `/careers` for now