### PR TITLE
Allow folders inside the /videos and /images directories

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -24,8 +24,8 @@ module.exports = function(eleventyConfig) {
     eleventyConfig.addPassthroughCopy("src/CNAME");
     eleventyConfig.addPassthroughCopy({"src/favicon/*":"/"});
     eleventyConfig.addPassthroughCopy("src/.well-known")
-    eleventyConfig.addPassthroughCopy("src/**/images/*");
-    eleventyConfig.addPassthroughCopy("src/**/videos/*");
+    eleventyConfig.addPassthroughCopy("src/**/images/**/*");
+    eleventyConfig.addPassthroughCopy("src/**/videos/**/*");
 
 
     eleventyConfig.addFilter("head", (array, n) => {


### PR DESCRIPTION
As part of on-going work in https://github.com/flowforge/handbook/issues/126 it would be useful to have sub-directories in the `/images` folder. Independent from that issue, this would be useful for future scaling & organisation anyway.