### PR TITLE
Prevent over-generalization of image styling

### DIFF
--- a/src/css/style.nohero.css
+++ b/src/css/style.nohero.css
@@ -84,3 +84,14 @@
     margin-top: 0;
     margin-bottom: 1rem;
 }
+
+/* Reset Tailwind CSS to enable more custom uses of images, e.g. User Personas */
+.handbook .prose img {
+    margin-top: initial;
+    margin-bottom: initial;
+}
+
+.handbook .prose > img {
+    margin-top: 2em;
+    margin-bottom: 2em;
+}


### PR DESCRIPTION
In https://github.com/flowforge/handbook/pull/135 we used `<img>` elements nested in a user persona tile, which picks up the standard Tailwind `margin-top: 2em; margin-bottom 2em;` styling. 

To clean this and for future nested img use cases, I have re-written the top-level CSS to define img margins