### PR TITLE
fix: Link of security statement

### DIFF
--- a/src/pricing.njk
+++ b/src/pricing.njk
@@ -61,7 +61,7 @@ layout: layouts/page.njk
     </div>
     <p class="max-w-screen-lg m-auto mt-12 text-center">
         At FlowForge we understand that the security practises of our product
-        are important to your company. We've prepared a <a href="./security">security statement</a>
+        are important to your company. We've prepared a <a href="../product/security">security statement</a>
         for you to understand the choices we've made.
     </p>
 </div>


### PR DESCRIPTION
The link was moved out the the product path into another, but the URL wasn't updated. This change updates the URL.