### PR TITLE
copy: Replace K8s for Kubernetes

### DIFF
--- a/src/index.njk
+++ b/src/index.njk
@@ -82,7 +82,7 @@ layout: default
             <div class="w-full px-3 mt-4 sm:w-72 md:mt-0 css-full">
                 <img class="w-40 m-auto mb-4" src="./images/pictograms/opensource.png"/>
                 <h5 class="flex justify-center">Open Source</h5>
-                <label class="font-light mt-2 block">Try for free with deployment options including Docker and K8s.</label>
+                <label class="font-light mt-2 block">Try for free with deployment options including Docker and Kubernetes.</label>
                 <a class="mt-4 ff-btn ff-btn--secondary inline-block" href="./docs/install">Install</a>
             </div>
             <div class="w-full px-3 mt-4 sm:w-72 md:mt-0">

--- a/src/node-red.njk
+++ b/src/node-red.njk
@@ -111,7 +111,7 @@ heroLg: true
             <div class="w-full px-3 mt-4 sm:w-72 md:mt-0 css-full">
                 <img class="w-40 m-auto mb-4" src="/images/pictograms/opensource.png"/>
                 <h5 class="flex justify-center">Open Source</h5>
-                <label class="text-white mt-2 block">Try for free with deployment options including Docker and K8s.</label>
+                <label class="text-white mt-2 block">Try for free with deployment options including Docker and Kubernetes.</label>
                 <a class="mt-4 ff-btn ff-btn--secondary inline-block" href="./docs/install">Install</a>
             </div>
             <div class="w-full px-3 mt-4 sm:w-72 md:mt-0">

--- a/src/pricing.njk
+++ b/src/pricing.njk
@@ -12,7 +12,7 @@ layout: layouts/page.njk
                 <h2>$0</h2>
                 <label class="sub-label">Apache 2.0 Licensed<label>
             </div>
-            <p class="mt-4">We are an open-core company, use FlowForge for free with deployment options including Docker and K8s</p>
+            <p class="mt-4">We are an open-core company, use FlowForge for free with deployment options including Docker and Kubernetes.</p>
             <a class="ff-btn ff-btn--secondary" href="/docs/install">Install now</a>
         </div>
     </div>


### PR DESCRIPTION
K8s is the abreviation not everyone might be aware off so let's replace it with its explicit form.