### PR TITLE
analytics: Add HubSpot

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -114,4 +114,5 @@ document.getElementById('nav-toggle').onclick = function(){
     classes.toggle("hidden");
 }
 </script>
+<script type="text/javascript" id="hs-script-loader" async defer src="//js-eu1.hs-scripts.com/26586079.js"></script>
 </html>


### PR DESCRIPTION
To analyse how our content and pages work with our targeted users tracking is added from HubSpot.

The content type feature of HubSpot is not yet implemented, and will have to wait until a future iteration.