### PR TITLE
Add footnotes support

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,11 +1,11 @@
 const markdownIt = require("markdown-it")
 const markdownItAnchor = require("markdown-it-anchor")
+const markdownItFootnote = require("markdown-it-footnote")
 const spacetime = require("spacetime");
 const heroGen = require("./lib/post-hero-gen.js");
 const countryFlag = require("./lib/country-flag-emoji");
 const pluginMermaid = require("@kevingimbel/eleventy-plugin-mermaid");
 const { stringify } = require("postcss");
-
 
 module.exports = function(eleventyConfig) {
     eleventyConfig.setWatchThrottleWaitTime(200); // in milliseconds
@@ -125,10 +125,9 @@ module.exports = function(eleventyConfig) {
         })
     }
 
-    const markdownLib = markdownIt(markdownItOptions).use(
-        markdownItAnchor,
-        markdownItAnchorOptions
-    )
+    const markdownLib = markdownIt(markdownItOptions)
+    .use(markdownItAnchor, markdownItAnchorOptions)
+    .use(markdownItFootnote)
 
     const syntaxHighlight = require("@11ty/eleventy-plugin-syntaxhighlight");
     eleventyConfig.addPlugin(syntaxHighlight);

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
                 "@11ty/eleventy-plugin-syntaxhighlight": "^4.0.0",
                 "@tailwindcss/typography": "^0.4.1",
                 "markdown-it-anchor": "^8.4.1",
+                "markdown-it-footnote": "^3.0.3",
                 "nodemon": "^2.0.15",
                 "npm-run-all": "^4.1.5",
                 "postcss": "^8.3.11",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
         "@11ty/eleventy-plugin-syntaxhighlight": "^4.0.0",
         "@tailwindcss/typography": "^0.4.1",
         "markdown-it-anchor": "^8.4.1",
+        "markdown-it-footnote": "^3.0.3",
         "nodemon": "^2.0.15",
         "npm-run-all": "^4.1.5",
         "postcss": "^8.3.11",

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -468,3 +468,19 @@ h4:hover .header-anchor {
 pre.mermaid {
     background-color: #ffffff
 }
+/*
+    FlowForge markdown-it rendered footnote styles
+*/
+div.content hr.footnotes-sep {
+    margin-top: 3em;
+    margin-bottom: 1em;
+}
+div.content section.footnotes ol li,
+div.content section.footnotes ol li:before,
+div.content section.footnotes ol li p {
+    font-weight: 300;
+    font-family: 'roboto', sans-serif, 'system-ui';
+    color: theme(colors.gray.400);
+    font-size: 0.8rem;
+    line-height: 0.8rem;
+}


### PR DESCRIPTION
fixes #250 

Before...

![image](https://user-images.githubusercontent.com/44235289/203128992-b8b79b7a-8923-4cff-bf5f-588632ad83b4.png)


After...
![image](https://user-images.githubusercontent.com/44235289/203129231-6abcfaac-6ab6-4290-9a2b-6e41287807eb.png)


NOTE:
Basic CSS was added to target the default `footnotes` classes (MVP) The scope is deliberately tight to only condition the footnotes. At some point in the future, we might want to generate FlowForge specific classes for footnotes.