### PR TITLE
Update build task to pull docs from maintenance branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,24 +10,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out website repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: 'website'
       - name: Check out handbook repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: 'flowforge/handbook'
           path: 'handbook'
-      - id: flowforgeRelease
-        uses: pozetroninc/github-action-get-latest-release@master
-        with:
-          repository: flowforge/flowforge
-          excludes: prerelease, draft
       - name: Check out flowforge repository (to access the docs)
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: 'flowforge/flowforge'
-          ref: ${{ steps.flowforgeRelease.outputs.release }}
+          ref: maintenance
           path: 'flowforge'
       - name: Install jq
         run: sudo apt-get -qy install jq


### PR DESCRIPTION
The existing task looked up the latest release and pulled the docs from the corresponding branch.

This PR changes it to always just pull from the maintenance branch.