### PR TITLE
peopleops: Start standardizing job titles

### DIFF
--- a/src/_data/team/ben-hardill.json
+++ b/src/_data/team/ben-hardill.json
@@ -1,6 +1,6 @@
 {
     "name": "Ben Hardill",
-    "title": "Senior Software Engineer",
+    "title": "Senior Software Developer",
     "twitter": "hardillb",
     "github": "hardillb",
     "linkedin": "ben-hardill",

--- a/src/_data/team/pez-cuckow.json
+++ b/src/_data/team/pez-cuckow.json
@@ -1,6 +1,6 @@
 {
     "name": "Pez Cuckow",
-    "title": "Senior Software Engineer",
+    "title": "Senior Software Developer",
     "twitter": "Pezmc",
     "github": "Pezmc",
     "blog": "https://www.pezcuckow.com",


### PR DESCRIPTION
Standardizing helps long term with expectation management based on these titles, compensation ranges, and more.

The smallest iteration I could make was for Ben and Pez, so I started there.