### PR TITLE
Fix container of blog index to scale properly

### DIFF
--- a/src/blog.njk
+++ b/src/blog.njk
@@ -1,7 +1,7 @@
 ---
 layout: nohero
 ---
-<div class="w-full">
+<div class="container m-auto text-left max-w-4xl pb-24 w-full">
     {% if collections.posts.length > 0 %}
     <ul class="flex flex-wrap">
         {%- for item in collections.posts | reverse -%}


### PR DESCRIPTION
Fixes #274

The nohero layout was modified via https://github.com/flowforge/website/commit/542ed44a8c1982a169541d2839404ffdae46e26e but the blog index relied on that for its layout.

This pushes the container layout into the blogindex page as was done for the contact page.