### PR TITLE
misc: Add copy code button

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,6 +1,7 @@
 const markdownIt = require("markdown-it")
 const markdownItAnchor = require("markdown-it-anchor")
 const markdownItFootnote = require("markdown-it-footnote")
+const codeClipboard = require("eleventy-plugin-code-clipboard");
 const spacetime = require("spacetime");
 const heroGen = require("./lib/post-hero-gen.js");
 const countryFlag = require("./lib/country-flag-emoji");
@@ -125,12 +126,15 @@ module.exports = function(eleventyConfig) {
         })
     }
 
-    const markdownLib = markdownIt(markdownItOptions)
-    .use(markdownItAnchor, markdownItAnchorOptions)
-    .use(markdownItFootnote)
-
     const syntaxHighlight = require("@11ty/eleventy-plugin-syntaxhighlight");
-    eleventyConfig.addPlugin(syntaxHighlight);
+    eleventyConfig.addPlugin(syntaxHighlight)
+	  eleventyConfig.addPlugin(codeClipboard)
+
+
+    const markdownLib = markdownIt(markdownItOptions)
+      .use(markdownItAnchor, markdownItAnchorOptions)
+      .use(markdownItFootnote)
+			.use(codeClipboard.markdownItCopyButton)
 
     eleventyConfig.setLibrary("md", markdownLib)
 

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -128,13 +128,12 @@ module.exports = function(eleventyConfig) {
 
     const syntaxHighlight = require("@11ty/eleventy-plugin-syntaxhighlight");
     eleventyConfig.addPlugin(syntaxHighlight)
-	  eleventyConfig.addPlugin(codeClipboard)
-
+	eleventyConfig.addPlugin(codeClipboard)
 
     const markdownLib = markdownIt(markdownItOptions)
-      .use(markdownItAnchor, markdownItAnchorOptions)
-      .use(markdownItFootnote)
-			.use(codeClipboard.markdownItCopyButton)
+        .use(markdownItAnchor, markdownItAnchorOptions)
+        .use(markdownItFootnote)
+		.use(codeClipboard.markdownItCopyButton)
 
     eleventyConfig.setLibrary("md", markdownLib)
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ node_modules
 src/handbook
 src/docs/*
 !src/docs/docs.json
+
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
         "@flowforge/forge-ui-components": "^0.2.2",
         "@kevingimbel/eleventy-plugin-mermaid": "^1.1.0",
         "autoprefixer": "^10.3.7",
+        "eleventy-plugin-code-clipboard": "^0.0.9",
         "postcss-import": "^14.0.2",
         "seedrandom": "^3.0.5"
     },

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -106,6 +106,7 @@
             </div>
         </div>
     </footer>
+    {% initClipboardJS %}
 </body>
 <script src="/js/cc.min.js"></script>
 <script>

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -9,6 +9,8 @@
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
     <link rel="manifest" href="/site.webmanifest">
     <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#aa4444">
+    <!-- Syntax Highlighting CSS -->
+    <link href="https://unpkg.com/prismjs@1.20.0/themes/prism-tomorrow.css" rel="stylesheet">
     <meta name="msapplication-TileColor" content="#00aba9">
     <meta name="theme-color" content="#ffffff">
     <title>FlowForge | Open-Source platform to run Node-RED in production</title>

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -106,9 +106,33 @@ pre code {
     background: #030303
 }
 
+/*
+    Eleventy Code Clipboard Plugin
+*/
 .code-copy {
-        color: theme(colors.red.600);
+    color: theme(colors.teal.300);
 }
+.code-copy * {
+   transition: none;
+   -webkit-transition: none;
+}
+.code-copy:hover {
+    color: white;
+}
+
+.tooltipped::before {
+    color: black !important;
+    border-bottom-color: black !important;
+}
+
+.tooltipped::after {
+    background-color: black !important;
+    color: white !important;
+}
+
+/*
+    Other
+*/
 
 body {
     --cc-btn-primary-bg: theme(colors.teal.500);

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1,6 +1,8 @@
 @import "./style.base.css";
 @import "./style.page.css";
 @import "./style.nohero.css";
+@import url("https://cdn.jsdelivr.net/npm/@mdi/font@6.5.95/css/materialdesignicons.min.css");
+@import url("https://cdnjs.cloudflare.com/ajax/libs/Primer/19.1.1/tooltips.min.css");
 @import "../../node_modules/@flowforge/forge-ui-components/dist/forge-ui-components.css";
 @import "../../node_modules/vanilla-cookieconsent/dist/cookieconsent.css";
 
@@ -102,6 +104,10 @@ main .ff-bg-light a:hover {
 }
 pre code {
     background: #030303
+}
+
+.code-copy {
+        color: theme(colors.red.600);
 }
 
 body {


### PR DESCRIPTION
There's often a case on the website where a blog post adds a code block which users need copy. This change adds a button in the code block to allow the code block contents to be copied into their clipboard.

This change does add two JS libraries loaded based on a URL, which is something we might not want to do.

Further; there's a choice of styling. I've chosen the red as it has more contrast on both the white and dark code block background.

