### PR TITLE
Add !important to prose > code override

### DIFF
--- a/src/css/style.nohero.css
+++ b/src/css/style.nohero.css
@@ -50,10 +50,10 @@
 }
 
 .prose code::after {
-    content:''
+    content: '' !important;
 }
 .prose code::before {
-    content:''
+    content: '' !important;
 }
 
 .handbook .prose h2 {


### PR DESCRIPTION
Closes #276 

It seems the underlying tailwind default (which shows an ` before and after each code example) was overriding our override for some reason. This adds an `!important` to our removal of the `:before` and `:after` content to ensure it does not render.

Longer term and better fix for this would be to understand why tailwind's default styles are being imported twice, once before your own classes, and once after (which then overrides some of our styles)

Docs now we do not show `:
<img width="709" alt="Screenshot 2022-12-09 at 16 20 36" src="https://user-images.githubusercontent.com/99246719/206746451-a39bd640-7f21-45d7-a727-8bbe779f841d.png">
