### PR TITLE
fix-author-name-not-showing

### DIFF
--- a/src/blog/2022/12/node-red-exec-explained.md
+++ b/src/blog/2022/12/node-red-exec-explained.md
@@ -3,7 +3,7 @@ title: Node-RED Exec nodes explained
 subtitle: Node-RED by default comes with the Exec node. This node allows you to run a command as if you're on the command line. In this article we discuss how that can be useful and why exec is not included in FlowForge.
 description: Node-RED by default comes with the Exec node. This node allows you to run a command as if you're on the command line. In this article we discuss how that can be useful and why exec is not included in FlowForge.
 date: 2022-12-12
-authors: ["zj-van-de-weg"]
+authors: ["zeger-jan-van-de-weg"]
 ---
 
 Node-RED is written in Javascript, as are the custom nodes in the


### PR DESCRIPTION
It seems that the blog has some sort of validation of author names. If for example I change my name to be 'rob-mercer' it does not show but 'rob-marcer' works OK. It also seems that ZJ's name only shows when written as 'zeger-jan-van-de-weg'. My theory is it's checking the names against our team list, no idea how or why though. I've updated ZJ's name to fix it not showing, I've checked and the fix works locally.

When it does not show - https://d.pr/i/PM8DBq

When it shows - https://d.pr/i/mzykDS