### PR TITLE
Improve Handbook navigation with side-menu

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -93,6 +93,9 @@ module.exports = function(eleventyConfig) {
                 if (page.data.navTitle) {
                     accumulator[currentValue].name = page.data.navTitle
                 }
+                if (page.data.navGroup) {
+                    accumulator[currentValue].group = page.data.navGroup
+                }
                 return accumulator[currentValue].children
             }, nav)
             
@@ -113,9 +116,9 @@ module.exports = function(eleventyConfig) {
                 }
             }
             
-        }
-        
+        }        
         nestedChildrenToArray(nav)
+        console.log(nav)
         return nav;
     });
 

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -127,20 +127,22 @@ module.exports = function(eleventyConfig) {
         // add functionality to group to-level items for better navigation.
         // TODO: Not currently shown in UI, but here for future use as will improve nav
         let groups = {}
-        for (child of nav.handbook.children) {
-            if (child.group) {
-                const group = child.group
-                if (!groups[group]) {
-                    groups[group] = []
+        if (nav.handbook) {
+            for (child of nav.handbook.children) {
+                if (child.group) {
+                    const group = child.group
+                    if (!groups[group]) {
+                        groups[group] = []
+                    }
+                    groups[group].push(child)
                 }
-                groups[group].push(child)
             }
-        }
 
-        // sort top-level nav to ensure consistent nav ordering
-        nav.handbook.children.sort((a, b) => {
-            return a.name.localeCompare(b.name)
-        })
+            // sort top-level nav to ensure consistent nav ordering
+            nav.handbook.children.sort((a, b) => {
+                return a.name.localeCompare(b.name)
+            })
+        }
 
         return nav;
     });

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -79,8 +79,11 @@ module.exports = function(eleventyConfig) {
             return hierarchyA.length - hierarchyB.length
         }).map((page) => {
             // work out ToC Hierarchy
+            // split the folder URI/URL, as this defines our TOC Hierarchy
             const hierarchy = page.url.split('/').filter(n => n)
+            // recursively parse hte folder hierarchy and created our collection object
             const map = hierarchy.reduce((accumulator, currentValue, i) => {
+                // create a nested object detailing hte full handbook hierarchy
                 if (!accumulator[currentValue]) {
                     accumulator[currentValue] = {
                         'name': currentValue,
@@ -94,6 +97,7 @@ module.exports = function(eleventyConfig) {
                     if (page.data.navTitle) {
                         accumulator[currentValue].name = page.data.navTitle
                     }
+                    // TODO: navGroup will be used in the rendering of the ToC at a later stage
                     if (page.data.navGroup) {
                         accumulator[currentValue].group = page.data.navGroup
                     }
@@ -118,7 +122,8 @@ module.exports = function(eleventyConfig) {
                 }
             }
             
-        }        
+        }
+        // convert our objects to arrays so we can render in nunjucks
         nestedChildrenToArray(nav)
 
         // add functionality to group to-level items for better navigation.
@@ -134,7 +139,7 @@ module.exports = function(eleventyConfig) {
             }
         }
 
-        // sort top--level nav to ensure consistent nav ordering
+        // sort top-level nav to ensure consistent nav ordering
         nav.handbook.children.sort((a, b) => {
             return a.name.localeCompare(b.name)
         })

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -80,7 +80,6 @@ module.exports = function(eleventyConfig) {
         }).map((page) => {
             // work out ToC Hierarchy
             const hierarchy = page.url.split('/').filter(n => n)
-            console.log(hierarchy)
             const map = hierarchy.reduce((accumulator, currentValue) => {
                 if (!accumulator[currentValue]) {
                     accumulator[currentValue] = {
@@ -118,7 +117,25 @@ module.exports = function(eleventyConfig) {
             
         }        
         nestedChildrenToArray(nav)
-        console.log(nav)
+
+        // add functionality to group to-level items for better navigation.
+        // TODO: Not currently shown in UI, but here for future use as will improve nav
+        let groups = {}
+        for (child of nav.handbook.children) {
+            if (child.group) {
+                const group = child.group
+                if (!groups[group]) {
+                    groups[group] = []
+                }
+                groups[group].push(child)
+            }
+        }
+
+        // sort top--level nav to ensure consistent nav ordering
+        nav.handbook.children.sort((a, b) => {
+            return a.name.localeCompare(b.name)
+        })
+
         return nav;
     });
 

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -76,12 +76,13 @@ module.exports = function(eleventyConfig) {
             const hierarchyA = a.url.split('/').filter(n => n)
             const hierarchyB = b.url.split('/').filter(n => n)
             return hierarchyA.length - hierarchyB.length
-        }).map((page) => {
+        }).forEach((page) => {
             // work out ToC Hierarchy
             // split the folder URI/URL, as this defines our TOC Hierarchy
             const hierarchy = page.url.split('/').filter(n => n)
-            // recursively parse hte folder hierarchy and created our collection object
-            const map = hierarchy.reduce((accumulator, currentValue, i) => {
+            // recursively parse the folder hierarchy and created our collection object
+            // pass nav = {} as the first accumulator - build up hierarchy map of TOC
+            hierarchy.reduce((accumulator, currentValue, i) => {
                 // create a nested object detailing hte full handbook hierarchy
                 if (!accumulator[currentValue]) {
                     accumulator[currentValue] = {
@@ -89,10 +90,6 @@ module.exports = function(eleventyConfig) {
                         'url': page.url,
                         'children': {}
                     }
-                }
-                // only look at meta when we are at the end of the hierarchy, i.e. the page var aligns with the hierarchy tier
-                if (i === hierarchy.length - 1) {
-                    // defines a nice-to-read title for the navigation option
                     if (page.data.navTitle) {
                         accumulator[currentValue].name = page.data.navTitle
                     }
@@ -103,8 +100,6 @@ module.exports = function(eleventyConfig) {
                 }
                 return accumulator[currentValue].children
             }, nav)
-            
-            return map
         })
 
         // recursive functions to format our nav map to arrays

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -80,7 +80,7 @@ module.exports = function(eleventyConfig) {
         }).map((page) => {
             // work out ToC Hierarchy
             const hierarchy = page.url.split('/').filter(n => n)
-            const map = hierarchy.reduce((accumulator, currentValue) => {
+            const map = hierarchy.reduce((accumulator, currentValue, i) => {
                 if (!accumulator[currentValue]) {
                     accumulator[currentValue] = {
                         'name': currentValue,
@@ -88,12 +88,15 @@ module.exports = function(eleventyConfig) {
                         'children': {}
                     }
                 }
-                // defines a nice-to-read title for the navigation option
-                if (page.data.navTitle) {
-                    accumulator[currentValue].name = page.data.navTitle
-                }
-                if (page.data.navGroup) {
-                    accumulator[currentValue].group = page.data.navGroup
+                // only look at meta when we are at the end of the hierarchy, i.e. the page var aligns with the hierarchy tier
+                if (i === hierarchy.length - 1) {
+                    // defines a nice-to-read title for the navigation option
+                    if (page.data.navTitle) {
+                        accumulator[currentValue].name = page.data.navTitle
+                    }
+                    if (page.data.navGroup) {
+                        accumulator[currentValue].group = page.data.navGroup
+                    }
                 }
                 return accumulator[currentValue].children
             }, nav)

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -109,7 +109,11 @@ module.exports = function(eleventyConfig) {
         function nestedChildrenToArray (value) {
             for (const [key, entry] of Object.entries(value)) {
                 if (entry.children && Object.keys(entry.children).length > 0) {
+                    // ensure our grandchildren are all converted to arrays before
+                    // we convert the higher level object to an array
                     nestedChildrenToArray(entry.children)
+                    // now we have converted all grandchildren,
+                    // we can convert our children to an array
                     entry.children = childrenToArray(entry.children)
                 } else {
                     delete entry.children

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -4,7 +4,6 @@ const markdownItFootnote = require("markdown-it-footnote")
 const codeClipboard = require("eleventy-plugin-code-clipboard");
 const spacetime = require("spacetime");
 const heroGen = require("./lib/post-hero-gen.js");
-const countryFlag = require("./lib/country-flag-emoji");
 const pluginMermaid = require("@kevingimbel/eleventy-plugin-mermaid");
 const { stringify } = require("postcss");
 const util = require('util')

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -72,9 +72,15 @@ module.exports = function(eleventyConfig) {
         collection.getAll().filter((page) => {
             return page.data.tags?.includes('handbook')
             // url.indexOf('/handbook') === 0
+        }).sort((a, b) => {
+            // sort by depth, so we catch all the correct index.md routes
+            const hierarchyA = a.url.split('/').filter(n => n)
+            const hierarchyB = b.url.split('/').filter(n => n)
+            return hierarchyA.length - hierarchyB.length
         }).map((page) => {
             // work out ToC Hierarchy
             const hierarchy = page.url.split('/').filter(n => n)
+            console.log(hierarchy)
             const map = hierarchy.reduce((accumulator, currentValue) => {
                 if (!accumulator[currentValue]) {
                     accumulator[currentValue] = {

--- a/lib/country-flag-emoji.js
+++ b/lib/country-flag-emoji.js
@@ -1,8 +1,0 @@
-// Liften from: https://dev.to/jorik/country-code-to-flag-emoji-a21
-module.exports = function getFlagEmoji(countryCode) {
-  const codePoints = countryCode
-    .toUpperCase()
-    .split('')
-    .map(char =>  127397 + char.charCodeAt());
-  return String.fromCodePoint(...codePoints);
-}

--- a/scripts/copy_handbook.sh
+++ b/scripts/copy_handbook.sh
@@ -29,6 +29,9 @@ do
             echo "updated: $lastUpdate" >> $destFile
             echo "---" >> $destFile
             cat $file >> $destFile
+            # account for .md files with --- data defined
+            # remove ---\n--- with '': https://stackoverflow.com/a/1252191/193376
+            sed -i "" -e ':a' -e 'N' -e '$!ba' -e 's/---\n---\n//g' $destFile
          ;;
          *)
             cp $file $destFile

--- a/src/_includes/components/icons/chevron-down.svg
+++ b/src/_includes/components/icons/chevron-down.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
+</svg>

--- a/src/_includes/components/icons/chevron-up.svg
+++ b/src/_includes/components/icons/chevron-up.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 15.75l7.5-7.5 7.5 7.5" />
+</svg>

--- a/src/_includes/layouts/docs.njk
+++ b/src/_includes/layouts/docs.njk
@@ -1,0 +1,109 @@
+---
+layout: nohero
+tags: docs
+---
+<div class="ff-prose container m-auto text-left max-w-4xl pb-24" data-handbook>
+    <!-- Breadcrumbs -->
+    <div class="w-full mx-auto ff-bg-light">
+        <div class="font-medium border-b pb-1">
+            {% if version %}
+            v{{ version }}
+            {% endif %}
+            {{ page.filePathStem | handbookBreadcrumbs |safe }}
+        </div>
+    </div>
+    <div class="w-full mx-auto ff-bg-light flex flex-col md:flex-row">
+        <!-- Main Content -->
+        <div class="flex-grow order-last md:order-first">
+            <div class="mt-6 mb-4 prose prose-blue main-content">
+                {{ content | rewriteHandbookLinks(page) | safe }}
+            </div>
+        </div>
+        <!-- on this page -->
+        <div class="w-full md:w-64 md:ml-8 mt-4 md:mt-6 px-2">
+            <h3 class="font-medium border-b pb-1 mb-4">On this page</h3>
+            <ul id="toc" class="text-sm border-b mb-4"></ul>
+            <div class="text-sm pb-1 text-right mb-4"><a href="{{ page | handbookEditLink(originalPath) }}">Edit this page</a></div>
+            <div class="text-xs pb-1 text-right mb-4 italic">Updated: {{ updated }}</div>
+        </div>
+    </div>
+</div>
+<script>
+    // Generate "On this page"
+    let toc = document.getElementById("toc")
+
+    let currentTag = "";
+    let currentToc = toc;
+    let currentItem;
+
+    let activeTier = 0 // which index to read from the depth
+    let depth = [1, 1, 1, 1] // tracks the active number to render at each depth
+
+    document.querySelectorAll(".main-content > h2, .main-content > h3, .main-content > h4").forEach(function(n) {
+        // which level of "H_" are we working with, and which one did we see most recently
+        const level = parseInt(n.nodeName[1])
+        const prevLevel = currentTag.length > 1 ? parseInt(currentTag[1]) : 0
+
+        // add numbering to our headers for easier navigation
+        if (prevLevel === 0) {
+            activeTier = 0
+        } else if (prevLevel > level) {
+            activeTier -= (prevLevel - level)
+            depth[activeTier] += 1
+        } else if (prevLevel < level) {
+            activeTier += 1
+            depth[activeTier] = 1
+        } else {
+            depth[activeTier] += 1
+        }
+        const hText = n.childNodes[n.childNodes.length - 1] // get the text only from our header
+        let number = ''
+        for (var nH = 0; nH <= activeTier; nH++) {
+            if (nH > 0) {
+                number += '.'
+            }
+            number += `${depth[nH]}`
+        }
+        // style top level header as '1. Header'
+        if (activeTier === 0) {
+            hText.textContent = `${number}. ${hText.textContent}`
+        } else {
+            // then style children as '1.1 - Header'
+            hText.textContent = `${number} - ${hText.textContent}`
+        }
+
+    // Render Table of Contents
+        if (prevLevel > 0 && level - prevLevel < 0) {
+            // we are moving left with our indent
+            currentToc = toc;
+        } else if (prevLevel > 0 && level - prevLevel > 0) {
+            // we are creating a new, nested `<ul>`
+            currentToc = document.createElement("ul");
+            currentToc.classList.add("ml-4")
+            currentToc.classList.add("mt-2")
+            currentToc.classList.add("mb-4")
+            currentItem.append(currentToc);
+        }
+        currentTag = n.nodeName;
+        currentItem = document.createElement("li");
+        currentItem.classList.add("mb-2")
+        let currentLink = document.createElement("a");
+        currentItem.append(currentLink);
+        let link = n.getElementsByTagName('a')
+        currentLink.href = link[0].href;
+        currentLink.textContent = n.textContent.replace(/#\s+/g,"");
+        currentToc.append(currentItem);
+    })
+
+    // All external links open in new page
+    document.querySelectorAll("[data-handbook] a").forEach((link) => {
+        try {
+            if (!link.target && window.location.host !== new URL(link.href).host) {
+                link.target = "_blank";
+            }
+        } catch {
+            // Swallow errors
+        }
+    })
+</script>
+{% mermaid_js %}

--- a/src/_includes/layouts/handbook.njk
+++ b/src/_includes/layouts/handbook.njk
@@ -1,22 +1,104 @@
 ---
 layout: nohero
+tags: handbook
 ---
-<div class="handbook container m-auto text-left max-w-4xl pb-24" data-handbook>
-    <div class="w-full mx-auto ff-bg-light">
-        <div class="font-medium border-b pb-1">
-            {% if version %}
-            v{{ version }}
+<script>
+    function toggleNavList (el) {
+        const li = el.parentElement
+        li.classList.toggle('open')
+        const ul = li.nextElementSibling
+        ul.classList.toggle('open')
+        if (ul.style.maxHeight) {
+            ul.style.maxHeight = null;
+        } else {
+            if (ul.parentElement.tagName === "UL" && !ul.parentElement.classList.contains('handbook-nav')) {
+                ul.parentElement.style.maxHeight = "initial"
+            }
+            ul.style.maxHeight = ul.scrollHeight + "px";
+            console.log(ul.parentElement.classList.contains('handbook-nav'))
+        } 
+    }
+</script>
+
+<div class="handbook ff-prose text-left pb-24" data-handbook>
+    <!-- Navigation -->
+    <ul class="handbook-nav border-r" data-el="navigation">
+        <li class="{% if "/handbook/" === page.url %}active{% endif %}">
+            <a href="/handbook">Handbook</a>
+        </li>
+        {# {{ collections.nav.handbook.children | console | safe }} #}
+        {% for entry in collections.nav.handbook.children %}
+        <li class="{% if entry.url === page.url %}active{% endif %}">
+            <a href="{{entry.url}}">
+                {{ entry.name }}
+            </a>
+            {% if entry.children %}
+            <button onclick="toggleNavList(this)">
+                <span class="ff-icon icon-expand">
+                    {% include "components/icons/chevron-down.svg" %}
+                </span>
+                <span class="ff-icon icon-minimise">
+                    {% include "components/icons/chevron-up.svg" %}
+                </span>
+            </button>
             {% endif %}
-            {{ page.filePathStem | handbookBreadcrumbs |safe }}
-        </div>
-    </div>
-    <div class="w-full mx-auto ff-bg-light flex flex-col md:flex-row">
-        <div class="flex-grow order-last md:order-first">
-            <div class="mt-6 mb-4 prose prose-blue main-content">
-                {{ content | rewriteHandbookLinks(page) | safe }}
+        </li>
+        {% if entry.children %}
+        <ul class="handbook-nav-nested">
+            {% for child in entry.children %}
+            <li class="{% if child.url === page.url %}active{% endif %}">
+                <a href="{{child.url}}">
+                    {{ child.name }}
+                </a>
+                {% if child.children %}
+                <button onclick="toggleNavList(this)">
+                    <span class="ff-icon icon-expand">
+                        {% include "components/icons/chevron-down.svg" %}
+                    </span>
+                    <span class="ff-icon icon-minimise">
+                        {% include "components/icons/chevron-up.svg" %}
+                    </span>
+                </button>
+                {% endif %}
+            </li>
+            {% if child.children %}
+            <ul class="handbook-nav-nested-2">
+                {% for grandchild in entry.children %}
+                <li class="{% if grandchild.url === page.url %}active{% endif %}">
+                    <a href="{{grandchild.url}}">
+                        {{ grandchild.name }}
+                    </a>
+                </li>
+                {% endfor %}
+            </ul>
+            {% endif %}
+            {% endfor %}
+        </ul>
+        {% endif %}
+        {% endfor %}
+    </ul>
+    <div class="max-w-screen-lg mx-auto px-8">
+        <!-- Breadcrumbs -->
+        <div class="w-full mx-auto ff-bg-light">
+            <div class="font-medium border-b pb-1">
+                {% if version %}
+                v{{ version }}
+                {% endif %}
+                {{ page.filePathStem | handbookBreadcrumbs |safe }}
             </div>
         </div>
-        <div class="w-full md:w-64 md:ml-8 mt-4 md:mt-6 px-2">
+        <div class="w-full mx-auto ff-bg-light flex flex-col md:flex-row">
+            <!-- Main Content -->
+            <div class="flex-grow order-last md:order-first">
+                <div class="mt-6 mb-4 prose prose-blue main-content">
+                    {{ content | rewriteHandbookLinks(page) | safe }}
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="border-l">
+        <!-- on this page -->
+        <div class="w-full md:w-64 mt-4 md:mt-6 px-8">
             <h3 class="font-medium border-b pb-1 mb-4">On this page</h3>
             <ul id="toc" class="text-sm border-b mb-4"></ul>
             <div class="text-sm pb-1 text-right mb-4"><a href="{{ page | handbookEditLink(originalPath) }}">Edit this page</a></div>
@@ -25,7 +107,12 @@ layout: nohero
     </div>
 </div>
 <script>
-    // Generate TOC
+    // Generate "Handbook Navigation"
+
+
+
+
+    // Generate "On this page"
     let toc = document.getElementById("toc")
 
     let currentTag = "";
@@ -61,12 +148,12 @@ layout: nohero
             number += `${depth[nH]}`
         }
         // style top level header as '1. Header'
-        if (activeTier === 0) {
+        {# if (activeTier === 0) {
             hText.textContent = `${number}. ${hText.textContent}`
         } else {
             // then style children as '1.1 - Header'
             hText.textContent = `${number} - ${hText.textContent}`
-        }
+        } #}
 
     // Render Table of Contents
         if (prevLevel > 0 && level - prevLevel < 0) {

--- a/src/_includes/layouts/handbook.njk
+++ b/src/_includes/layouts/handbook.njk
@@ -31,7 +31,7 @@ tags: handbook
             {% for entry in collections.nav.handbook.children %}
             <li class="{% if entry.url === page.url %}active{% endif %}">
                 <a href="{{entry.url}}">
-                    {{ entry.name }}
+                    {{ entry.name }} {{ entry.group }}
                 </a>
                 {% if entry.children %}
                 <button onclick="toggleNavList(this)">
@@ -80,8 +80,8 @@ tags: handbook
         </ul>
     </div>
     <div class="max-w-screen-lg mx-auto px-8 pt-8">
-        <!-- Breadcrumbs -->
-        <div class="w-full mx-auto ff-bg-light">
+        <!-- Breadcrumbs - Desktop -->
+        <div class="hidden w-full mx-auto ff-bg-light md:block">
             <div class="font-medium border-b pb-1">
                 {% if version %}
                 v{{ version }}
@@ -99,9 +99,18 @@ tags: handbook
         </div>
     </div>
     <div class="border-l">
+        <!-- Breadcrumbs - Mobile -->
+        <div class="block px-8 pt-4 w-full mx-auto ff-bg-light md:hidden">
+            <div class="font-medium border-b pb-1">
+                {% if version %}
+                v{{ version }}
+                {% endif %}
+                {{ page.filePathStem | handbookBreadcrumbs |safe }}
+            </div>
+        </div>
         <!-- on this page -->
         <div class="sticky top-6 w-full md:w-64 mt-4 md:mt-6 px-8">
-            <h3 class="font-medium border-b pb-1 mb-4">On this page</h3>
+            <h3 class="font-medium border-b pb-1 mb-4">on this page</h3>
             <ul id="toc" class="text-sm border-b mb-4"></ul>
             <div class="text-sm pb-1 text-right mb-4"><a href="{{ page | handbookEditLink(originalPath) }}">Edit this page</a></div>
             <div class="text-xs pb-1 text-right mb-4 italic">Updated: {{ updated }}</div>

--- a/src/_includes/layouts/handbook.njk
+++ b/src/_includes/layouts/handbook.njk
@@ -63,7 +63,7 @@ tags: handbook
             </li>
             {% if child.children %}
             <ul class="handbook-nav-nested-2">
-                {% for grandchild in entry.children %}
+                {% for grandchild in child.children %}
                 <li class="{% if grandchild.url === page.url %}active{% endif %}">
                     <a href="{{grandchild.url}}">
                         {{ grandchild.name }}

--- a/src/_includes/layouts/handbook.njk
+++ b/src/_includes/layouts/handbook.njk
@@ -22,35 +22,18 @@ tags: handbook
 
 <div class="handbook ff-prose text-left pb-24" data-handbook>
     <!-- Navigation -->
-    <ul class="handbook-nav border-r" data-el="navigation">
-        <li class="{% if "/handbook/" === page.url %}active{% endif %}">
-            <a href="/handbook">Handbook</a>
-        </li>
-        {# {{ collections.nav.handbook.children | console | safe }} #}
-        {% for entry in collections.nav.handbook.children %}
-        <li class="{% if entry.url === page.url %}active{% endif %}">
-            <a href="{{entry.url}}">
-                {{ entry.name }}
-            </a>
-            {% if entry.children %}
-            <button onclick="toggleNavList(this)">
-                <span class="ff-icon icon-expand">
-                    {% include "components/icons/chevron-down.svg" %}
-                </span>
-                <span class="ff-icon icon-minimise">
-                    {% include "components/icons/chevron-up.svg" %}
-                </span>
-            </button>
-            {% endif %}
-        </li>
-        {% if entry.children %}
-        <ul class="handbook-nav-nested">
-            {% for child in entry.children %}
-            <li class="{% if child.url === page.url %}active{% endif %}">
-                <a href="{{child.url}}">
-                    {{ child.name }}
+    <div>
+        <ul class="handbook-nav border-r" data-el="navigation">
+            <li class="{% if "/handbook/" === page.url %}active{% endif %}">
+                <a href="/handbook">Handbook</a>
+            </li>
+            {# {{ collections.nav.handbook.children | console | safe }} #}
+            {% for entry in collections.nav.handbook.children %}
+            <li class="{% if entry.url === page.url %}active{% endif %}">
+                <a href="{{entry.url}}">
+                    {{ entry.name }}
                 </a>
-                {% if child.children %}
+                {% if entry.children %}
                 <button onclick="toggleNavList(this)">
                     <span class="ff-icon icon-expand">
                         {% include "components/icons/chevron-down.svg" %}
@@ -61,23 +44,42 @@ tags: handbook
                 </button>
                 {% endif %}
             </li>
-            {% if child.children %}
-            <ul class="handbook-nav-nested-2">
-                {% for grandchild in child.children %}
-                <li class="{% if grandchild.url === page.url %}active{% endif %}">
-                    <a href="{{grandchild.url}}">
-                        {{ grandchild.name }}
+            {% if entry.children %}
+            <ul class="handbook-nav-nested">
+                {% for child in entry.children %}
+                <li class="{% if child.url === page.url %}active{% endif %}">
+                    <a href="{{child.url}}">
+                        {{ child.name }}
                     </a>
+                    {% if child.children %}
+                    <button onclick="toggleNavList(this)">
+                        <span class="ff-icon icon-expand">
+                            {% include "components/icons/chevron-down.svg" %}
+                        </span>
+                        <span class="ff-icon icon-minimise">
+                            {% include "components/icons/chevron-up.svg" %}
+                        </span>
+                    </button>
+                    {% endif %}
                 </li>
+                {% if child.children %}
+                <ul class="handbook-nav-nested-2">
+                    {% for grandchild in child.children %}
+                    <li class="{% if grandchild.url === page.url %}active{% endif %}">
+                        <a href="{{grandchild.url}}">
+                            {{ grandchild.name }}
+                        </a>
+                    </li>
+                    {% endfor %}
+                </ul>
+                {% endif %}
                 {% endfor %}
             </ul>
             {% endif %}
             {% endfor %}
         </ul>
-        {% endif %}
-        {% endfor %}
-    </ul>
-    <div class="max-w-screen-lg mx-auto px-8">
+    </div>
+    <div class="max-w-screen-lg mx-auto px-8 pt-8">
         <!-- Breadcrumbs -->
         <div class="w-full mx-auto ff-bg-light">
             <div class="font-medium border-b pb-1">
@@ -98,7 +100,7 @@ tags: handbook
     </div>
     <div class="border-l">
         <!-- on this page -->
-        <div class="w-full md:w-64 mt-4 md:mt-6 px-8">
+        <div class="sticky top-6 w-full md:w-64 mt-4 md:mt-6 px-8">
             <h3 class="font-medium border-b pb-1 mb-4">On this page</h3>
             <ul id="toc" class="text-sm border-b mb-4"></ul>
             <div class="text-sm pb-1 text-right mb-4"><a href="{{ page | handbookEditLink(originalPath) }}">Edit this page</a></div>

--- a/src/_includes/layouts/handbook.njk
+++ b/src/_includes/layouts/handbook.njk
@@ -31,7 +31,7 @@ tags: handbook
             {% for entry in collections.nav.handbook.children %}
             <li class="{% if entry.url === page.url %}active{% endif %}">
                 <a href="{{entry.url}}">
-                    {{ entry.name }} {{ entry.group }}
+                    {{ entry.name }}
                 </a>
                 {% if entry.children %}
                 <button onclick="toggleNavList(this)">

--- a/src/_includes/layouts/handbook.njk
+++ b/src/_includes/layouts/handbook.njk
@@ -118,11 +118,6 @@ tags: handbook
     </div>
 </div>
 <script>
-    // Generate "Handbook Navigation"
-
-
-
-
     // Generate "On this page"
     let toc = document.getElementById("toc")
 
@@ -138,35 +133,7 @@ tags: handbook
         const level = parseInt(n.nodeName[1])
         const prevLevel = currentTag.length > 1 ? parseInt(currentTag[1]) : 0
 
-        // add numbering to our headers for easier navigation
-        if (prevLevel === 0) {
-            activeTier = 0
-        } else if (prevLevel > level) {
-            activeTier -= (prevLevel - level)
-            depth[activeTier] += 1
-        } else if (prevLevel < level) {
-            activeTier += 1
-            depth[activeTier] = 1
-        } else {
-            depth[activeTier] += 1
-        }
-        const hText = n.childNodes[n.childNodes.length - 1] // get the text only from our header
-        let number = ''
-        for (var nH = 0; nH <= activeTier; nH++) {
-            if (nH > 0) {
-                number += '.'
-            }
-            number += `${depth[nH]}`
-        }
-        // style top level header as '1. Header'
-        {# if (activeTier === 0) {
-            hText.textContent = `${number}. ${hText.textContent}`
-        } else {
-            // then style children as '1.1 - Header'
-            hText.textContent = `${number} - ${hText.textContent}`
-        } #}
-
-    // Render Table of Contents
+        // Render Table of Contents
         if (prevLevel > 0 && level - prevLevel < 0) {
             // we are moving left with our indent
             currentToc = toc;

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1,6 +1,7 @@
 @import "./style.base.css";
 @import "./style.page.css";
 @import "./style.nohero.css";
+@import "./style.handbook.css";
 @import url("https://cdn.jsdelivr.net/npm/@mdi/font@6.5.95/css/materialdesignicons.min.css");
 @import url("https://cdnjs.cloudflare.com/ajax/libs/Primer/19.1.1/tooltips.min.css");
 @import "../../node_modules/@flowforge/forge-ui-components/dist/forge-ui-components.css";

--- a/src/css/style.handbook.css
+++ b/src/css/style.handbook.css
@@ -1,0 +1,96 @@
+@tailwind components;
+@tailwind utilities;
+
+@layer components {
+    .handbook {
+        display: grid;
+        grid-template-columns: 265px 1fr auto;
+    }
+
+    .handbook-nav {
+        border-right: 1px solid right;
+        text-transform: capitalize;
+        --nav-weight: 600;
+        /* --nav-color: white; */
+        --nav-color: black;
+        --nav-bg: theme(colors.gray.50);
+        --nav-pl: 1rem;
+        background-color: theme(colors.gray.50);
+        padding-left: 0.5rem;
+    }
+
+    .handbook-nav-nested {
+        --nav-bg: theme(colors.gray.50);
+        --nav-color: black;
+        --nav-weight: 300;
+        --nav-pl: 1.25rem;
+        margin-left: 1.25rem;
+    }
+
+    .handbook-nav-nested-2 {
+        margin-left: 1.25rem;
+    }
+
+    .handbook-nav li {
+        @apply flex justify-between items-stretch my-1;
+        font-weight: var(--nav-weight);
+        background-color: var(--nav-bg);
+        border-left: 4px solid;
+        border-color: var(--nav-bg);
+    }
+
+    .handbook-nav li a {
+        color: var(--nav-color) !important;
+        flex-grow: 1;
+        @apply py-1.5 px-4;
+        padding-left: var(--nav-pl);
+    }
+
+    .handbook-nav li button {
+        @apply px-2;
+    }
+    
+    .handbook-nav li.active {
+        background-color: theme(colors.gray.100);
+        border-color: theme(colors.red.600);
+    }
+
+    .handbook-nav li:hover {
+        background-color: theme(colors.gray.200);
+    }
+
+    .handbook li .ff-icon {
+        padding-right: 1rem;
+    }
+
+    .handbook li .icon-expand {
+        display: block;
+    }
+
+    .handbook li .icon-minimise {
+        display: none;
+    }
+
+    .handbook li.open {
+        background-color: theme(colors.gray.100);
+    }
+
+    .handbook li.open .icon-expand {
+        display: none;
+    }
+
+    .handbook li.open .icon-minimise {
+        display: block;
+    }
+
+    /* Define animation transitions for all child UL elements */
+    .handbook-nav ul {
+        max-height: 0;
+        overflow-y: hidden;
+        transition: 0.3s;
+    }
+
+    .handbook-nav ul:has(li.active) {
+        max-height: initial;
+    }
+}

--- a/src/css/style.handbook.css
+++ b/src/css/style.handbook.css
@@ -3,9 +3,9 @@
 
 @layer components {
     .handbook {
-        display: grid;
         grid-template-columns: 265px 1fr auto;
         margin-top: -3rem;
+        @apply flex flex-col-reverse md:grid
     }
 
     .handbook-nav {

--- a/src/css/style.handbook.css
+++ b/src/css/style.handbook.css
@@ -5,6 +5,7 @@
     .handbook {
         display: grid;
         grid-template-columns: 265px 1fr auto;
+        margin-top: -3rem;
     }
 
     .handbook-nav {
@@ -17,6 +18,8 @@
         --nav-pl: 1rem;
         background-color: theme(colors.gray.50);
         padding-left: 0.5rem;
+        padding-top: 1.5rem;
+        @apply sticky top-0;
     }
 
     .handbook-nav-nested {

--- a/src/css/style.nohero.css
+++ b/src/css/style.nohero.css
@@ -56,34 +56,34 @@
     content: '' !important;
 }
 
-.handbook .prose h2 {
+.ff-prose .prose h2 {
     font-size: 1.75rem;
 }
 
-.handbook .prose h3 {
+.ff-prose .prose h3 {
     font-size: 1.5rem;
 }
 
-.handbook .prose h4 {
+.ff-prose .prose h4 {
     font-size: 1.25rem;
 }
 
-.handbook .prose h5 {
+.ff-prose .prose h5 {
     font-size: 1rem;
 }
 
-.handbook .prose p {
+.ff-prose .prose p {
     margin-top: 0;
     margin-bottom: 1rem;
 }
 
 /* Reset Tailwind CSS to enable more custom uses of images, e.g. User Personas */
-.handbook .prose img {
+.ff-prose .prose img {
     margin-top: initial;
     margin-bottom: initial;
 }
 
-.handbook .prose > img {
+.ff-prose .prose > img {
     margin-top: 2em;
     margin-bottom: 2em;
 }

--- a/src/docs/docs.json
+++ b/src/docs/docs.json
@@ -1,5 +1,5 @@
 {
-    "layout": "layouts/handbook.njk",
+    "layout": "layouts/docs.njk",
     "tags": [
         "docs"
     ]


### PR DESCRIPTION
## Description

https://user-images.githubusercontent.com/99246719/210655691-659a6bf8-c537-44b9-924b-5bc1beb764b9.mov

Introduces new side navigation into the Handbook. In order to do this, I have split the `handbook` and `docs` layout templates, as this is not currently required in the docs.

Side navigation items are positioned as `sticky` so do stay with scroll, also designed to be mobile friendly.

This utilises meta data added in this [Handbook PR](https://github.com/flowforge/handbook/pull/177), so they will need to be merged concurrently.

**For a later date...**

Navigation ordering and grouping will need to be improved at a later stage, in addition to changes directly in the structure of Handbook, as the Handbook folders have their own `index.md` files which are navigated to by clicking the element that contains the dropdown expansion to see child elements (shown in demo recording).

Side navigation would benefit from being a swipable hidden item, with toggle button, but given handbook traffic is all desktop, no rush on this.

## Related Issue(s)

Issue: https://github.com/flowforge/website/issues/193
Paired with development changes in [Handbook PR](https://github.com/flowforge/handbook/pull/177)

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)

