### PR TITLE
Handbook Navigation Groups & Optional Ordering

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -123,7 +123,6 @@ module.exports = function(eleventyConfig) {
         nestedChildrenToArray(nav)
 
         // add functionality to group to-level items for better navigation.
-        // TODO: Not currently shown in UI, but here for future use as will improve nav
         let groups = {
             'Other': {
                 name: 'Other',

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -5,9 +5,7 @@ const codeClipboard = require("eleventy-plugin-code-clipboard");
 const spacetime = require("spacetime");
 const heroGen = require("./lib/post-hero-gen.js");
 const pluginMermaid = require("@kevingimbel/eleventy-plugin-mermaid");
-const { stringify } = require("postcss");
 const util = require('util')
-const fg = require('fast-glob');
 
 module.exports = function(eleventyConfig) {
     eleventyConfig.setWatchThrottleWaitTime(200); // in milliseconds
@@ -126,21 +124,48 @@ module.exports = function(eleventyConfig) {
 
         // add functionality to group to-level items for better navigation.
         // TODO: Not currently shown in UI, but here for future use as will improve nav
-        let groups = {}
+        let groups = {
+            'Other': {
+                name: 'Other',
+                order: -1,    // always render last
+                children: []
+            }
+        }
+        // not req'd to have handbook in Website build, so this may be empty
         if (nav.handbook) {
             for (child of nav.handbook.children) {
                 if (child.group) {
                     const group = child.group
                     if (!groups[group]) {
-                        groups[group] = []
+                        groups[group] = {
+                            name: group,
+                            order: 0,
+                            children: []
+                        }
                     }
-                    groups[group].push(child)
+                    groups[group].children.push(child)
+                } else {
+                    // capture & flag top-level handbook docs, that haven't had a group assigned
+                    groups['Other'].children.push(child)
                 }
             }
 
-            // sort top-level nav to ensure consistent nav ordering
-            nav.handbook.children.sort((a, b) => {
-                return a.name.localeCompare(b.name)
+            function sortChildren (a, b) {
+                // sort children by 'order', then alphabetical
+                return b.order - a.order || a.name.localeCompare(b.name)
+            }
+
+            nav.handbook.groups = Object.values(groups).sort(sortChildren)
+            
+            nav.handbook.groups.forEach((group) => {
+                if (group.children) {
+                    group.children.forEach((child) => {
+                        if (child.children) {
+                            child.children.sort(sortChildren)
+                        }
+                    })
+                    group.children.sort(sortChildren)
+                }
             })
         }
 

--- a/src/_includes/layouts/handbook.njk
+++ b/src/_includes/layouts/handbook.njk
@@ -15,7 +15,6 @@ tags: handbook
                 ul.parentElement.style.maxHeight = "initial"
             }
             ul.style.maxHeight = ul.scrollHeight + "px";
-            console.log(ul.parentElement.classList.contains('handbook-nav'))
         } 
     }
 </script>
@@ -28,30 +27,15 @@ tags: handbook
                 <a href="/handbook">Handbook</a>
             </li>
             {# {{ collections.nav.handbook.children | console | safe }} #}
-            {% for entry in collections.nav.handbook.children %}
-            <li class="{% if entry.url === page.url %}active{% endif %}">
-                <a href="{{entry.url}}">
-                    {{ entry.name }}
-                </a>
-                {% if entry.children %}
-                <button onclick="toggleNavList(this)">
-                    <span class="ff-icon icon-expand">
-                        {% include "components/icons/chevron-down.svg" %}
-                    </span>
-                    <span class="ff-icon icon-minimise">
-                        {% include "components/icons/chevron-up.svg" %}
-                    </span>
-                </button>
-                {% endif %}
-            </li>
-            {% if entry.children %}
-            <ul class="handbook-nav-nested">
-                {% for child in entry.children %}
-                <li class="{% if child.url === page.url %}active{% endif %}">
-                    <a href="{{child.url}}">
-                        {{ child.name }}
+            {% for group in collections.nav.handbook.groups %}
+            {% if group.children.length > 0 %}
+            <li class="handbook-nav-group">{{ group.name }}</li>
+                {% for entry in group.children %}
+                <li class="{% if entry.url === page.url %}active{% endif %}">
+                    <a href="{{entry.url}}">
+                        {{ entry.name }}
                     </a>
-                    {% if child.children %}
+                    {% if entry.children %}
                     <button onclick="toggleNavList(this)">
                         <span class="ff-icon icon-expand">
                             {% include "components/icons/chevron-down.svg" %}
@@ -62,21 +46,44 @@ tags: handbook
                     </button>
                     {% endif %}
                 </li>
-                {% if child.children %}
-                <ul class="handbook-nav-nested-2">
-                    {% for grandchild in child.children %}
-                    <li class="{% if grandchild.url === page.url %}active{% endif %}">
-                        <a href="{{grandchild.url}}">
-                            {{ grandchild.name }}
+                {% if entry.children %}
+                <ul class="handbook-nav-nested">
+                    {% for child in entry.children %}
+                    <li class="{% if child.url === page.url %}active{% endif %}">
+                        <a href="{{child.url}}">
+                            {{ child.name }}
                         </a>
+                        {% if child.children %}
+                        <button onclick="toggleNavList(this)">
+                            <span class="ff-icon icon-expand">
+                                {% include "components/icons/chevron-down.svg" %}
+                            </span>
+                            <span class="ff-icon icon-minimise">
+                                {% include "components/icons/chevron-up.svg" %}
+                            </span>
+                        </button>
+                        {% endif %}
                     </li>
+                    {% if child.children %}
+                    <ul class="handbook-nav-nested-2">
+                        {% for grandchild in child.children %}
+                        <li class="{% if grandchild.url === page.url %}active{% endif %}">
+                            <a href="{{grandchild.url}}">
+                                {{ grandchild.name }}
+                            </a>
+                        </li>
+                        {% endfor %}
+                    </ul>
+                    {% endif %}
                     {% endfor %}
                 </ul>
                 {% endif %}
                 {% endfor %}
-            </ul>
             {% endif %}
             {% endfor %}
+
+
+            
         </ul>
     </div>
     <div class="max-w-screen-lg mx-auto px-8 pt-8">

--- a/src/css/style.handbook.css
+++ b/src/css/style.handbook.css
@@ -42,15 +42,32 @@
         border-color: var(--nav-bg);
     }
 
-    .handbook-nav li a {
-        color: var(--nav-color) !important;
+    .handbook-nav li a,
+    .handbook-nav li.handbook-nav-group {
         flex-grow: 1;
         @apply py-1.5 px-4;
+    }
+
+    .handbook-nav li.handbook-nav-group {
+        color: theme(colors.red.700);
+        padding-left: 0;
+    }
+
+    .handbook-nav li a {
+        color: var(--nav-color) !important;
         padding-left: var(--nav-pl);
+    }
+
+    .handbook li .ff-icon {
+        padding-right: 1rem;
     }
 
     .handbook-nav li button {
         @apply px-2;
+    }
+
+    .handbook-nav li button:hover .ff-icon svg path {
+        stroke: theme(colors.blue.600);
     }
     
     .handbook-nav li.active {
@@ -58,16 +75,14 @@
         border-color: theme(colors.red.600);
     }
 
-    .handbook-nav li:hover {
+    .handbook-nav li a:hover {
         background-color: theme(colors.gray.200);
     }
 
-    .handbook li .ff-icon {
-        padding-right: 1rem;
-    }
 
     .handbook li .icon-expand {
         display: block;
+        color: black;
     }
 
     .handbook li .icon-minimise {


### PR DESCRIPTION
## Description

https://user-images.githubusercontent.com/99246719/210894092-630efccd-412e-41ef-8ef2-c2fae7cebbaa.mov

- Adds top-level navigation groups to make navigation clearer.
- Adds `order` to a group in order to force "Other" to the bottom if rendered. 
    - Currently doesn't get controlled by any data at the `.md` level, would be nice to control ordering this way too, but it's excessive for now
- Removes old imports

## Related Issue(s)

Follow on to https://github.com/flowforge/website/pull/304

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
