### PR TITLE
Define "capture" function & trigger in appropriate places

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -40,6 +40,12 @@
     <script>
         !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
         posthog.init('phc_KBFEQWMxoXMXrHId1Cn8bjSmvzR5MHoNaOIacYPpQdi',{api_host:'https://app.posthog.com'})
+
+        function capture (eventName, props) {
+            if (posthog) {
+                posthog.capture(eventName, props);
+            }
+        }
     </script>
 </head>
 <body class="ff-website leading-normal tracking-normal gradient text-gray-500 min-h-screen flex flex-col" style="">
@@ -93,7 +99,7 @@
                         <li class="inline mr-3 mb-3 md:m-0 md:block"><a href="https://www.youtube.com/channel/UCbBzP8NZbv3WDtlt4UouA-g">YouTube</a></li>
                         <li class="inline mr-3 mb-3 md:m-0 md:block"><a href="https://www.linkedin.com/company/flowforge-inc">LinkedIn</a></li>
                         <li class="inline mr-3 mb-3 md:m-0 md:block"><a href="/blog/index.xml">RSS Feed</a></li>
-                        <li class="inline mr-3 mb-3 md:m-0 md:block"><a href="/blog/#sign-up">Sign Up to Mailing List</a></li>
+                        <li class="inline mr-3 mb-3 md:m-0 md:block"><a href="/blog/#sign-up" onclick="capture('cta-blog-subscribe', {'position': 'footer'})">Sign Up to Mailing List</a></li>
                     </ul>
                 </div>
                 <div class="w-full">

--- a/src/blog.njk
+++ b/src/blog.njk
@@ -45,7 +45,7 @@ sitemapPriority: 0.9
                 action="https://buttondown.email/api/emails/embed-subscribe/flowforge"
                 method="post"
                 target="popupwindow"
-                onsubmit="window.open('https://buttondown.email/flowforge', 'popupwindow')"
+                onsubmit="capture('cta-blog-subscribe', {'position': 'primary'}); window.open('https://buttondown.email/flowforge', 'popupwindow')"
                 class="embeddable-buttondown-form my-1 ">
                 <div class="flex flex-col sm:flex-row">
                     <input type="email" name="email" id="bd-email" placeholder="Enter your email" class="ff-input ff-text-input lg:w-80 md:w-60" />

--- a/src/index.njk
+++ b/src/index.njk
@@ -13,8 +13,8 @@ sitemapPriority: 1.0
         </p>
         <div class="flex flex-col">
           <div class="m-auto mt-6 flex flex-col gap-4 sm:flex-row items-center justify-center">
-            <a class="ff-btn ff-btn--secondary" href="./docs/install">Install on your own infrastructure</a>
-            <a class="ff-btn ff-btn--primary" href="https://app.flowforge.com/account/create">Join FlowForge Cloud</a>
+            <a class="ff-btn ff-btn--secondary" href="./docs/install" onclick="capture('cta-install', {'position': 'primary'})">Install on your own infrastructure</a>
+            <a class="ff-btn ff-btn--primary" href="https://app.flowforge.com/account/create" onclick="capture('cta-join', {'position': 'primary'})">Join FlowForge Cloud</a>
           </div>
         </div>
     </div>
@@ -84,13 +84,13 @@ sitemapPriority: 1.0
                 <img class="w-40 m-auto mb-4" src="./images/pictograms/opensource.png" alt="Graphics depicting the Open-Source logo."/>
                 <h5 class="flex justify-center">Open Source</h5>
                 <label class="font-light mt-2 block">Try for free with deployment options including Docker and Kubernetes.</label>
-                <a class="mt-4 ff-btn ff-btn--secondary inline-block" href="./docs/install">Install</a>
+                <a class="mt-4 ff-btn ff-btn--secondary inline-block" href="./docs/install" onclick="capture('cta-install', {'position': 'secondary'})">Install</a>
             </div>
             <div class="w-full px-3 mt-4 sm:w-72 md:mt-0">
                 <img class="w-40 m-auto mb-4" src="./images/pictograms/enterprise.png" alt="Graphic image representing 'Infrastructure'."/>
                 <h5 class="flex justify-center">FlowForge Cloud</h5>
                 <label class="font-light mt-2 block">Get started in less than a minute, fully managed, fully secure.</label>
-                <a class="mt-4 ff-btn ff-btn--primary inline-block" href="https://app.flowforge.com/account/create">Join Now</a>
+                <a class="mt-4 ff-btn ff-btn--primary inline-block" href="https://app.flowforge.com/account/create" onclick="capture('cta-join', {'position': 'secondary'})">Join Now</a>
             </div>
         </div>
     </div>

--- a/src/pricing.njk
+++ b/src/pricing.njk
@@ -14,7 +14,7 @@ sitemapPriority: 0.90
                 <label class="sub-label">Apache 2.0 Licensed<label>
             </div>
             <p class="mt-4">We are an open-core company, use FlowForge for free with deployment options including Docker and Kubernetes.</p>
-            <a class="ff-btn ff-btn--secondary" href="/docs/install">Install now</a>
+            <a class="ff-btn ff-btn--secondary" href="/docs/install" onclick="capture('cta-install', {'position': 'primary'})">Install now</a>
         </div>
     </div>
     <div class="pricing-tile pt-4 pb-6 px-8">
@@ -29,13 +29,13 @@ sitemapPriority: 0.90
             <div class="sm:w-6/12">
                 <h5>FlowForge Cloud</h5>
                 <p class="mt-2">Get started in less than a minute, fully managed, fully secure.</p>
-                <a class="ff-btn ff-btn--primary" href="https://app.flowforge.com/account/create">Sign up</a>
+                <a class="ff-btn ff-btn--primary" href="https://app.flowforge.com/account/create" onclick="capture('cta-join', {'position': 'primary'})">Sign up</a>
             </div>
             <span style="width: 2px; background-color: gray; height: 75%"></span>
             <div class="sm:w-6/12">
                 <h5>Self-Managed</h5>
                 <p class="mt-2">Premium features, on your own dedicated instance.</p>
-                <a class='ff-btn ff-btn--secondary' href='/contact-us'>Contact Us</a>
+                <a class='ff-btn ff-btn--secondary' href='/contact-us' onclick="capture('cta-enterprise', {'position': 'primary'})">Contact Us</a>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Description

Whilst we already capture CTA data in PostHog through the Autocapture events, defining custom events provides additional functionality and easier filtering. As such, I have defined `cta-*` events, that are triggered across the FlowForge website.

The events are as follows:

| Event | Detail |
|------|--------|
| cta-install | Clicking any button/links, with the intention of installing a local copy of FlowForge. In this case, the user is directed to our docs. |
| cta-join | Clicking any button/links, with the intention of joining FlowForge Cloud |
| cta-enterprise | Clicking any button/links with the intention of running FF Premium, self-managed. Currently, this is via the "Contact Us" option on our homepage. |
| cta-news-subscribe | Tracks a visitor taking intentional moves to subscribe to our mailing list/news. |

For these `cta-*` events, I have also included meta-data for `position`. This is meant to dictate where on the page the CTA is placed:

| Position | Detail |
|------|--------|
| primary | A key feature/attraction that draws the eye on first load of a page |
| secondary | Positioned within the body of a page |
| footer | Positioned in the footer of the website |
| header | (not currently used) Positioned in the header of the website |

## Related Issue(s)

Closes #208 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
