### PR TITLE
sitemap: Add full URL, not only path

### DIFF
--- a/src/sitemap.njk
+++ b/src/sitemap.njk
@@ -6,7 +6,7 @@ eleventyExcludeFromCollections: true
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
     {% for page in collections.all %}
         <url>
-            <loc>{{ site.url }}{{ page.url | url }}</loc>
+            <loc>{{ site.baseURL }}{{ page.url | url }}</loc>
             <lastmod>{{ page.date.toISOString() }}</lastmod>
             <priority>{{ page.data.sitemapPriority | default(0.6) }}</priority>
         </url>


### PR DESCRIPTION
As in our `_data/site.json` we called URL baseURL the sitemap generating script only generated the path element. That created errors for consumers of the sitemap.

This change make sure the baseURL is used, and is prepended to the path. As such it should improve indexing.


