### PR TITLE
Change "per/project" to "per Node-RED instance/month"

### DIFF
--- a/src/pricing.njk
+++ b/src/pricing.njk
@@ -22,7 +22,7 @@ sitemapPriority: 0.90
             <h4>Premium</h4>
             <div>
                 <h2>$15</h2>
-                <label class="sub-label">per project/mo</label>
+                <label class="sub-label">per Node-RED instance/month</label>
             </div>
         </div>
         <div class="flex flex-col sm:flex-row items-center gap-4 mt-4">


### PR DESCRIPTION
## Description

As per the proposal in https://github.com/flowforge/flowforge/issues/1450#issuecomment-1372564433 and agreement in the [Product Sync on January 10th, 2023](https://docs.google.com/document/d/18mL6W2Oe7eK0RVNit9KKM5PpDFO9yoTx9cHy8R14_cE/edit#) we have changed our pricing language from "per project" to "per Node-RED".

Given the screen real estate available here, I chose to go with the full "per Node-RED instance/month" for clarity:

<img width="1221" alt="Screenshot 2023-01-10 at 20 44 44" src="https://user-images.githubusercontent.com/99246719/211660556-1a475b9a-7590-4eef-9d38-6b72281310fa.png">

<img width="419" alt="Screenshot 2023-01-10 at 20 44 59" src="https://user-images.githubusercontent.com/99246719/211660560-fde3e4a0-f45a-40b3-8af9-ea85f2b411cb.png">


## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)