### PR TITLE
Fix: Dynamic SVG divider widths

### DIFF
--- a/src/_includes/components/divider-grey-wires-left--dark.njk
+++ b/src/_includes/components/divider-grey-wires-left--dark.njk
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="982" height="70" fill="none" viewBox="0 0 982 70">
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 982 70">
   <path stroke="#374151" stroke-width="4" d="M982 35H0m773 0c-115 0-88 27-188 27m-99-27c-115 0-88 27-188 27"/>
   <rect width="12" height="12" x="591" y="68" fill="#1F2937" stroke="#374151" stroke-width="4" rx="2" transform="rotate(180 591 68)"/>
   <rect width="12" height="12" x="304" y="68" fill="#1F2937" stroke="#374151" stroke-width="4" rx="2" transform="rotate(180 304 68)"/>

--- a/src/_includes/components/divider-grey-wires-right--dark.njk
+++ b/src/_includes/components/divider-grey-wires-right--dark.njk
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="982" height="70" fill="none" viewBox="0 0 982 70">
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 982 70">
   <path stroke="#374151" stroke-width="4" d="M0 35h982m-773 0c115 0 88-27 188-27m99 27c115 0 88-27 188-27"/>
   <rect width="12" height="12" x="391" y="2" fill="#1F2937" stroke="#374151" stroke-width="4" rx="2"/>
   <rect width="12" height="12" x="678" y="2" fill="#1F2937" stroke="#374151" stroke-width="4" rx="2"/>


### PR DESCRIPTION
## Description

Two of the divider SVGs had hard-coded widths on them. Removing them makes the SVGs dynamically size, and therefore prevents overflow on mobile.

**before:**

<img width="518" alt="Screenshot 2023-01-14 at 08 42 23" src="https://user-images.githubusercontent.com/99246719/212463968-9d46657f-ddb8-4137-a659-a1e37266023f.png">

**after:**

<img width="576" alt="Screenshot 2023-01-14 at 08 41 19" src="https://user-images.githubusercontent.com/99246719/212463946-84a92ca2-da10-4c1f-a78c-f8bbd8eb5ad8.png">

## Related Issue(s)

Fixes #327 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [-] Suitable unit/system level tests have been added and they pass
 - [-] Documentation has been updated
    - [-] Upgrade instructions
    - [-] Configuration details
    - [-] Concepts

## Labels

 - [-] Backport needed? -> add the `backport` label
 - [-] Includes a DB migration? -> add the `area:migration` label

