### PR TITLE
Add PH events for when visitors click the Feature info icons

### DIFF
--- a/src/_includes/feature_lists/cloud.njk
+++ b/src/_includes/feature_lists/cloud.njk
@@ -115,11 +115,12 @@
 %}
 
 <script>
-    function openInfo(row) {
-        document.getElementById("ff-dialog--feature--"+row).classList.add('active')
+    function openInfo(label, id) {
+        capture('info-feature', { feature: id})
+        document.getElementById("ff-dialog--feature--" + label).classList.add('active')
     }
-    function closeInfo(row) {
-        document.getElementById("ff-dialog--feature--"+row).classList.remove('active')
+    function closeInfo(label) {
+        document.getElementById("ff-dialog--feature--" + label).classList.remove('active')
     }
 </script>
 
@@ -144,7 +145,7 @@
             <label>
                 {{ row.label }}
                 {% if row.info %}
-                <i id="ff-info--{{ row.id }}" class="ff-icon" onclick="openInfo('{{ row.label }}')">{% include "components/icons/info.svg" %}</i>
+                <i id="ff-info--{{ row.id }}" class="ff-icon" onclick="openInfo('{{ row.label }}', '{{ row.id }}')">{% include "components/icons/info.svg" %}</i>
                 {% endif %}
             </label>
             {% for value in row.values %}


### PR DESCRIPTION
## Description

Noticed in our session recordings within PostHog that it's common for visitors to interact with the "i" icons of our Features in the /pricing page.

Whilst each element has a unique `id`, it's a little annoying to configure neat analysis on these within PostHog. Having a custom event with a parameters indicating the relevant feature will make this a lot easier to understand what visitors want more information about.

## Related Issue(s)

None

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)