### PR TITLE
Optional title/description properties per Website page

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -13,9 +13,16 @@
     <link href="https://unpkg.com/prismjs@1.20.0/themes/prism-tomorrow.css" rel="stylesheet">
     <meta name="msapplication-TileColor" content="#00aba9">
     <meta name="theme-color" content="#ffffff">
-    <title>FlowForge | Run Node-RED in Production</title>
     <meta name="description" content="Scale your Node-RED deployments in production. Open-Source and available on Docker, Kubernetes or Cloud">
     <meta name="keywords" content="Node-RED, Deployment, Production, Enterprise, IoT, IIoT, Low-Code, Open-Source, Kubernetes, Docker, Cloud, Hosting">
+
+    {% if meta and meta.title %}
+    <title>{{ meta.title }} &#x2022; FlowForge</title>
+    {% elif title %}
+    <title>{{ title }} &#x2022; FlowForge</title>
+    {% else %}
+    <title>FlowForge &#x2022; Run Node-RED in Production</title>
+    {% endif %}
 
     {% if tags and 'posts' in tags %}
     <meta name="twitter:card" content="summary" />

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -13,9 +13,9 @@
     <link href="https://unpkg.com/prismjs@1.20.0/themes/prism-tomorrow.css" rel="stylesheet">
     <meta name="msapplication-TileColor" content="#00aba9">
     <meta name="theme-color" content="#ffffff">
-    <meta name="description" content="Scale your Node-RED deployments in production. Open-Source and available on Docker, Kubernetes or Cloud">
     <meta name="keywords" content="Node-RED, Deployment, Production, Enterprise, IoT, IIoT, Low-Code, Open-Source, Kubernetes, Docker, Cloud, Hosting">
 
+    <!-- Browser Title -->
     {% if meta and meta.title %}
     <title>{{ meta.title }} &#x2022; FlowForge</title>
     {% elif title %}
@@ -24,31 +24,52 @@
     <title>FlowForge &#x2022; Run Node-RED in Production</title>
     {% endif %}
 
-    {% if tags and 'posts' in tags %}
-    <meta name="twitter:card" content="summary" />
-    <meta name="twitter:site" content="@flowforgeinc" />
-    <meta name="twitter:creator" content="@{{ team[authors|first].twitter }}" />
+    <!-- Browser Description -->
+    {% if meta and meta.description %}
+    <meta name="description" content="{{ meta.description }}">
+    {% else %}
+    <meta name="description" content="Scale your Node-RED deployments in production. Open-Source and available on Docker, Kubernetes or Cloud">
+    {% endif %}
+
+    <!-- Open Graph Title -->
+    {% if meta and meta.title %}
+    <meta property="og:title" content="{{ meta.title }} &#x2022; FlowForge" />
+    {% elif title %}
+    <meta property="og:title" content="{{ title }} &#x2022; FlowForge" />
+    {% else %}
+    <meta property="og:title" content="FlowForge &#x2022; Run Node-RED in Production" />
+    {% endif %}
+
+    <!-- Open Graph Description -->
+    {% if meta and meta.description %}
+    <meta property="og:description" content="{{ meta.description }}" />
+    {% elif description %}
+    <meta property="og:description" content="{{ description }}" />
+    {% else %}
+    <meta property="og:description" content="FlowForge is an open-source, low-code platform for integration and automation. Helping you run Node-RED at production scales in a secure, scalable and team-based environment." />
+    {% endif %}
+
+    <!-- Open Graph URL -->
     <meta property="og:url" content="{{ site.baseURL }}{{ page.url }}" />
-    <meta property="og:title" content="{{title}}" />
-    <meta property="og:description" content="{{description}}" />
+    <!-- Open Graph Image -->
     {% if image %}
     <meta property="og:image" content="{{ site.baseURL }}{{image}}" />
     {% else %}
     <meta property="og:image" content="{{ site.baseURL }}/images/og-social-tile.jpg" />
     {% endif %}
+
+    {% if tags and 'posts' in tags %}
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:site" content="@flowforgeinc" />
+    <meta name="twitter:creator" content="@{{ team[authors|first].twitter }}" />
     {% else %}
+    <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:description" content="FlowForge is an open-source, low-code platform for integration and automation. Helping you run Node-RED at production scales in a secure, scalable and team-based environment." />
+    <meta name="twitter:description" content="" />
     <meta name="twitter:site" content="@flowforgeinc" />
     <meta name="twitter:image" content="/images/og-social-tile.jpg" />
-    <meta property="og:url" content="{{ site.baseURL }}{{ page.url }}" />
-    <meta property="og:title" content="{{title}}" />
-    <meta property="og:description" content="FlowForge is an open-source, low-code platform for integration and automation. Helping you run Node-RED at production scales in a secure, scalable and team-based environment." />
-    {% if image %}
-    <meta property="og:image" content="{{ site.baseURL }}{{image}}" />
-    {% else %}
-    <meta property="og:image" content="{{ site.baseURL }}/images/og-social-tile.jpg" />
-    {% endif %}    {% endif %}
+    {% endif %}    
 
     <script>
         !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);

--- a/src/_includes/layouts/docs.njk
+++ b/src/_includes/layouts/docs.njk
@@ -1,6 +1,8 @@
 ---
 layout: nohero
 tags: docs
+meta:
+    title: Docs
 ---
 <div class="ff-prose container m-auto text-left max-w-4xl pb-24" data-handbook>
     <!-- Breadcrumbs -->

--- a/src/_includes/layouts/handbook.njk
+++ b/src/_includes/layouts/handbook.njk
@@ -1,6 +1,8 @@
 ---
 layout: nohero
 tags: handbook
+meta:
+    title: Handbook
 ---
 <script>
     function toggleNavList (el) {

--- a/src/about.njk
+++ b/src/about.njk
@@ -5,6 +5,8 @@ description: "<p>FlowForge is an open core company creating a low-code programmi
 <p>We're still in our infancy, but here is a bit about who are are, what we believe in and how we operate.</p>"
 heroimg: "../images/pictograms/anvil1.png"
 sitemapPriority: 0.7
+meta:
+    title: About
 ---
 
 {% include "components/divider-flow--default.njk" %}

--- a/src/blog.njk
+++ b/src/blog.njk
@@ -1,6 +1,8 @@
 ---
 layout: nohero
 sitemapPriority: 0.9
+meta:
+    title: Blog
 ---
 <div class="container m-auto text-left max-w-4xl pb-24 w-full">
     {% if collections.posts.length > 0 %}

--- a/src/features.njk
+++ b/src/features.njk
@@ -5,6 +5,8 @@ description: <p>FlowForge is an open-source platform for managing IT and OT inte
 heroimg: "../images/features.png"
 heroWide: true
 sitemapPriority: 0.9
+meta:
+    description: Explore the features available in the FlowForge platform.
 ---
 
 <div class="-mt-24 md:-mt-32">

--- a/src/pricing.njk
+++ b/src/pricing.njk
@@ -3,6 +3,8 @@ title: Pricing
 align: center
 layout: layouts/page.njk
 sitemapPriority: 0.90
+meta:
+    description: Find out how much it costs to use FlowForge.
 ---
 
 <div class="px-6 pricing-tiles flex flex-col md:grid mb-16 md:max-w-screen-lg">

--- a/src/pricing.njk
+++ b/src/pricing.njk
@@ -1,5 +1,5 @@
 ---
-title: FlowForge Pricing
+title: Pricing
 align: center
 layout: layouts/page.njk
 sitemapPriority: 0.90

--- a/src/privacy-policy.md
+++ b/src/privacy-policy.md
@@ -1,6 +1,8 @@
 ---
 layout: nohero
 sitemapPriority: 0.7
+meta:
+    title: Privacy Policy
 ---
 
 <div class="prose prose-blue container m-auto max-w-4xl">


### PR DESCRIPTION
## Description

Add two new optional properties in the website `.njk`/`.md` files

```
meta:
    title: <title goes here>
    description: <description goes here>
```

The browser title & `og:title` will use `meta.title` if it exists, alternatively, it'll fall back to the `title` property used on our `layout/page` and finally falls back to our default `FlowForge` title.

The `og:description` will read from `meta.description` if available, then the `description` field (as used in blog articles, and finally fall back to the default that we use now.

I've also added titles/descriptions where appropriate, but it'll be very easy to add more of these on a page-by-page basis going forward.

## Related Issue(s)

Closes #337 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [-] Suitable unit/system level tests have been added and they pass
 - [-] Documentation has been updated
    - [-] Upgrade instructions
    - [-] Configuration details
    - [-] Concepts
 - [-] Changes `flowforge.yml`?
    - [-] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [-] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [-] Backport needed? -> add the `backport` label
 - [-] Includes a DB migration? -> add the `area:migration` label

