### PR TITLE
Replace button down with HubSpot form

### DIFF
--- a/src/_includes/layouts/post.njk
+++ b/src/_includes/layouts/post.njk
@@ -31,20 +31,19 @@ layout: layouts/base.njk
                 </div>
                 {{ content | safe }}
             </div>
-            <div class="mt-12 pt-12 flex flex-col border-t-2">
+            <div class="mt-12 pt-6 flex flex-col border-t-2">
                 <h3 class="mb-6">Sign up for updates</h3>
-                <form
-                    action="https://buttondown.email/api/emails/embed-subscribe/flowforge"
-                    method="post"
-                    target="popupwindow"
-                    onsubmit="window.open('https://buttondown.email/flowforge', 'popupwindow')"
-                    class="embeddable-buttondown-form my-1 ">
-                    <div class="flex flex-col sm:flex-row">
-                        <input type="email" name="email" id="bd-email" placeholder="Enter your email" class="ff-input ff-text-input lg:w-80 md:w-60" />
-                        <input type="hidden" value="1" name="embed" />
-                        <input type="submit" value="Subscribe" class="ff-btn ff-btn--primary w-full mt-3 sm:w-auto sm:mt-0 sm:ml-3"/>
-                    </div>
-                </form>
+                <script charset="utf-8" type="text/javascript" src="//js-eu1.hsforms.net/forms/embed/v2.js"></script>
+                <script>
+                    hbspt.forms.create({
+                        region: "eu1",
+                        portalId: "26586079",
+                        formId: "159c173d-dd95-49bd-922b-ff3ef243e90c",
+                        onFormSubmit: function($form) {
+                            capture('cta-blog-subscribe', {'position': 'article'})
+                        }
+                    });
+                </script>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Description

This uses the same HubSpot form at the bottom of each blog now, rather than the redundant button down form.

We may want to look at moving anybody over that subscribed to the buttondown form in the past 10 days or so since we stopped using that?

The form is also now linked to PostHog too, so we'll get a breakdown of everyone subscribing by article too (have added to the Blog report)

## Related Issue(s)

Closes https://github.com/flowforge/content/issues/38

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)