### PR TITLE
Add px to docs for mobile viewing

### DIFF
--- a/src/_includes/layouts/docs.njk
+++ b/src/_includes/layouts/docs.njk
@@ -4,7 +4,7 @@ tags: docs
 meta:
     title: Docs
 ---
-<div class="ff-prose container m-auto text-left max-w-4xl pb-24" data-handbook>
+<div class="ff-prose container m-auto text-left max-w-4xl px-4 pb-24" data-handbook>
     <!-- Breadcrumbs -->
     <div class="w-full mx-auto ff-bg-light">
         <div class="font-medium border-b pb-1">


### PR DESCRIPTION
## Description

Noticed in the session recordings that our docs have no padding on mobile, this adds it.

## Related Issue(s)

Closes #362 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)