### PR TITLE
Recording "info" event, not "register" event when viewing details of session

### DIFF
--- a/src/webinars.njk
+++ b/src/webinars.njk
@@ -14,7 +14,7 @@ meta:
             <ul>
                 <li class="webinar-tile">
                     <div class="flex flex-col md:flex-row">
-                        <a href="{{ item.url }}" onclick="capture('cta-webinar-register')" class="webinar-tile-img relative mb-4 md:mb-0 flex md:w-1/2 mr-2 rounded">
+                        <a href="{{ item.url }}" onclick="capture('cta-webinar-info')" class="webinar-tile-img relative mb-4 md:mb-0 flex md:w-1/2 mr-2 rounded">
                             {% if item.data.image %}
                                 <img class="w-full h-auto rounded" src="{{item.data.image}}" />
                             {% else %}


### PR DESCRIPTION
## Description

Was recording the "webinar-register" event when a visitor click for the details of a Webinar or AMA session, which meant PostHog was over-reporting registrations.

This fixes that.
