### PR TITLE
Better handling of page titles for the website/handbook

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -16,10 +16,12 @@
     <meta name="keywords" content="Node-RED, Deployment, Production, Enterprise, IoT, IIoT, Low-Code, Open-Source, Kubernetes, Docker, Cloud, Hosting">
 
     <!-- Browser Title -->
-    {% if meta and meta.title %}
-    <title>{{ meta.title }} &#x2022; FlowForge</title>
+    {% if navTitle %}
+    <title>{{ navTitle }} &#x2022; FlowForge{% if page.url.match('\/handbook\/.+') %} Handbook{% endif %}</title>
+    {% elif meta and meta.title %}
+    <title>{{ meta.title }} &#x2022; FlowForge{% if page.url.match('\/handbook\/.+') %} Handbook{% endif %}</title>
     {% elif title %}
-    <title>{{ title }} &#x2022; FlowForge</title>
+    <title>{{ title }} &#x2022; FlowForge{% if page.url.match('\/handbook\/.+') %} Handbook{% endif %}</title>
     {% else %}
     <title>FlowForge &#x2022; DevOps for Node-RED</title>
     {% endif %}
@@ -32,10 +34,12 @@
     {% endif %}
 
     <!-- Open Graph Title -->
-    {% if meta and meta.title %}
-    <meta property="og:title" content="{{ meta.title }} &#x2022; FlowForge" />
+    {% if navTitle %}
+    <meta property="og:title" content="{{ navTitle }} &#x2022; FlowForge{% if page.url.match('\/handbook\/.+') %} Handbook{% endif %}" />
+    {% elif meta and meta.title %}
+    <meta property="og:title" content="{{ meta.title }} &#x2022; FlowForge{% if page.url.match('\/handbook\/.+') %} Handbook{% endif %}" />
     {% elif title %}
-    <meta property="og:title" content="{{ title }} &#x2022; FlowForge" />
+    <meta property="og:title" content="{{ title }} &#x2022; FlowForge{% if page.url.match('\/handbook\/.+') %} Handbook{% endif %}" />
     {% else %}
     <meta property="og:title" content="FlowForge &#x2022; DevOps for Node-RED" />
     {% endif %}


### PR DESCRIPTION
## Description

Handbook URLs were being shared with the title "Handbook - FlowForge" and not specific to the page being shared. This allows use of the same `navTitle` that is used in the side navigation in order to better render preview titles of the content when shared.