### PR TITLE
Handle windows line endings when copying content from hb/docs

### DIFF
--- a/scripts/copy_docs.js
+++ b/scripts/copy_docs.js
@@ -31,7 +31,7 @@ async function copyFiles (src, dest, version) {
                     if (/^---/.test(content)) {
                         // The original file starts with yaml front-matter, so
                         // remove the double-delimter we've just introduced
-                        body = body.replace('---\n---\n', '')
+                        body = body.replace(/---\r?\n---\r?\n/s, '')
                     }
                     await fs.writeFile(destFile, body)
                 }

--- a/scripts/copy_handbook.js
+++ b/scripts/copy_handbook.js
@@ -30,7 +30,7 @@ async function copyFiles (src, dest) {
                     if (/^---/.test(content)) {
                         // The original file starts with yaml front-matter, so
                         // remove the double-delimter we've just introduced
-                        body = body.replace('---\n---\n', '')
+                        body = body.replace(/---\r?\n---\r?\n/s, '')
                     }
                     await fs.writeFile(destFile, body)
                 }


### PR DESCRIPTION
Handle Windows line endings when copying content from handbook/docs.