### PR TITLE
Link to "Newsletter" page & consistent page header styling

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -119,6 +119,7 @@
                             <a class="flex items-center gap-2">resources {% include "components/icons/chevron-down.svg" %}</a>
                             <ul>
                                 <li><a href="/blog">blog</a></li>
+                                <li><a href="/community/newsletter">newsletter</a></li>
                                 <li><a href="/webinars">webinars</a></li>
                             </ul>
                         </li>

--- a/src/blog.njk
+++ b/src/blog.njk
@@ -5,6 +5,12 @@ meta:
     title: Blog
 ---
 <div class="container m-auto text-left max-w-4xl pb-24 w-full">
+    <div class="px-2">
+        <h1>Blog</h1>
+        <div class="md:-mt-6">
+            {% include "components/divider-grey-wires-right.njk" %}
+        </div>
+    </div>
     {% if collections.posts.length > 0 %}
     <ul class="flex flex-wrap">
         {%- for item in collections.posts | reverse -%}

--- a/src/community/newsletter.njk
+++ b/src/community/newsletter.njk
@@ -4,8 +4,13 @@ sitemapPriority: 0.9
 ---
 
 <div class="container m-auto text-left max-w-4xl pb-24 w-full">
+    <div class="px-2">
+        <h1>Newsletter</h1>
+        <div class="md:-mt-6">
+            {% include "components/divider-grey-wires-right.njk" %}
+        </div>
+    </div>
     <ul class="flex flex-wrap">
-
         {% set newsletters = collections.newsletter %}
         {% for item in newsletters | reverse %}
         {% if loop.first %}

--- a/src/css/style.components.css
+++ b/src/css/style.components.css
@@ -59,7 +59,6 @@
     .webinar-tile a.webinar-tile-img img, 
     .webinar-tile a.webinar-tile-img svg {
         transition: transform 0.3s;
-        min-height: 250px;
     }
 
     .webinar-tile a.webinar-tile-img:hover img,

--- a/src/webinars.njk
+++ b/src/webinars.njk
@@ -5,8 +5,12 @@ meta:
     title: Webinars
 ---
 <div class="container m-auto text-left max-w-4xl pb-24 w-full px-2">
-    <h1>Webinars</h1>
-    {% include "components/divider-grey-wires-right.njk" %}
+    <div class="px-2">
+        <h1>Webinars</h1>
+        <div class="md:-mt-6">
+            {% include "components/divider-grey-wires-right.njk" %}
+        </div>
+    </div>
     {% if collections.webinar and collections.webinar.length > 0 %}
         {%- for item in collections.webinar | inFuture -%}
             {% if loop.first %}


### PR DESCRIPTION
## Description

- Adds "Newsletter" to the new "Resources" dropdown
- Makes the page header styling for Blog/Webinar/Newsletter consistent
- Adds a small CSS sizing fix for the AMA session image on mobile.

## Screenshots

<img width="1096" alt="Screenshot 2023-02-02 at 09 32 33" src="https://user-images.githubusercontent.com/99246719/216286354-e97b7920-755b-4f23-b42e-8ad55549525e.png">

<img width="1107" alt="Screenshot 2023-02-02 at 09 32 39" src="https://user-images.githubusercontent.com/99246719/216286360-22778093-eb28-4c88-b044-dfa1e0872504.png">

## Open Points:

@ZJvandeWeg @iskerrett do we still want to be listing the community newsletters amongst the Blog articles too? Or shall I remove the `post` tags from these so that they only now show on "Newsletter" page. Thinking the latter makes more sense?

## Related Issue(s)

Closes #378 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [-] Suitable unit/system level tests have been added and they pass
 - [-] Documentation has been updated
    - [-] Upgrade instructions
    - [-] Configuration details
    - [-] Concepts
 - [-] Changes `flowforge.yml`?
    - [-] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [-] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [-] Backport needed? -> add the `backport` label
 - [-] Includes a DB migration? -> add the `area:migration` label

