### PR TITLE
SEO: don't index some pages

### DIFF
--- a/src/404.njk
+++ b/src/404.njk
@@ -4,6 +4,7 @@ permalink: 404.html
 heading: "404"
 subheading: Flow stopped due to unknown type.
 layout: default
+skipIndex: true
 ---
 <div class="px-6 pb-24 md:max-w-lg mx-auto text-center">
     <img class="w-full mx-auto" src="/images/pictograms/404.png">

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -31,6 +31,10 @@
     <meta name="description" content="Scale your Node-RED deployments in production. Open-Source and available on Docker, Kubernetes or Cloud">
     {% endif %}
 
+    {% if skipIndex -%}
+    <meta name="robots" content="noindex">
+    {%- endif %}
+
     <!-- Open Graph Title -->
     {% if meta and meta.title %}
     <meta property="og:title" content="{{ meta.title }} &#x2022; FlowForge" />

--- a/src/redirect.md
+++ b/src/redirect.md
@@ -26,5 +26,6 @@ redirects:
 permalink: "{{ redirect.from }}"
 # The "redirect" layout just has a small html header with the meta tags that do redirection.
 layout: redirect
+skipIndex: true
 ---
 (the content can be left blank; it's entirely the frontmatter doing the work here.)

--- a/src/sitemap.njk
+++ b/src/sitemap.njk
@@ -4,11 +4,13 @@ eleventyExcludeFromCollections: true
 ---
 <?xml version="1.0" encoding="utf-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-    {% for page in collections.all %}
+    {% for page in collections.all -%}
+        {% if page.data.skipIndex != true %}
         <url>
             <loc>{{ page.url | url | toAbsoluteUrl }}</loc>
             <lastmod>{{ page.date.toISOString() }}</lastmod>
             <priority>{{ page.data.sitemapPriority | default(0.6) }}</priority>
         </url>
-    {% endfor %}
+	{% endif %}
+    {%- endfor %}
 </urlset>


### PR DESCRIPTION
Some pages need no indexing, like our 404 page, or redirected pages. This PR achieves that by allowing a flag on the front matter YAML.

This PR replaces: https://github.com/flowforge/website/pull/345

Part of: https://github.com/flowforge/website/issues/385