### PR TITLE
seo: Don't index the careers redirect

### DIFF
--- a/src/careers.njk
+++ b/src/careers.njk
@@ -2,6 +2,7 @@
 layout: "nohero"
 title: Careers
 sitemapPriority: 0.8
+skipIndex: true
 ---
 
 You will be re-directed to our job postings board


### PR DESCRIPTION
With setting 'skipIndex' a page doesn't end up in the sitemap, not will it be indexed by search engines. For the careers pages, that's a feature, as it's redirecting to greenhouse.