### PR TITLE
Webinar Fixes

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -84,7 +84,8 @@ module.exports = function(eleventyConfig) {
     eleventyConfig.addFilter('countDays', (date) => {
         // return true is the provided date is in the past, otherwise, return false
         const postDate = spacetime(date)
-        const days = spacetime.now().diff(postDate, 'days')
+        const now = spacetime.now()
+        const days = now.diff(postDate, 'day') + 1
         if (days === 0) {
             return { value: 0, text: 'Today'}
         } else if (days === 1) {

--- a/src/webinars/2023/getting-started-nodered.md
+++ b/src/webinars/2023/getting-started-nodered.md
@@ -1,7 +1,7 @@
 ---
 title: "Introduction to Node-RED: 5 minutes to your first program"
 subtitle: Join Rob Marcer, Developer Educator at FlowForge, for a webinar on getting started with Node-RED
-image: /images/webinars/webinar-wide.jpg
+image: /images/webinars/webinar-nr-5mins.jpg
 date: 2023-02-23
 time: 16:00 GMT (11:00 ET) 
 duration: 60


### PR DESCRIPTION
## Description

- Point to the correct image for Webinar
- Force the `diff()` call to return correct value, is always out by one ([have raised issue with spacetime](https://github.com/spencermountain/spacetime/issues/371))

## Related Issue(s)

Fixed problems introduced in #400

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)