### PR TITLE
Show date instead of "X Days Away" for Webinar

### DIFF
--- a/src/webinars.njk
+++ b/src/webinars.njk
@@ -20,7 +20,7 @@ meta:
             {%- for item in collections.webinar | inFuture -%}
                 {% if loop.first %}
                 <div>
-                    <h2 class="w-full">Upcoming Webinar: <span class="text-red-600 italic text-lg ml-2">{{ (item.date | countDays).text }}</span></h2>
+                    <h2 class="w-full">Upcoming Webinar: <span class="text-red-600 italic text-lg ml-2">{{ item.date.toLocaleDateString(undefined, { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' }) }}</span></h2>
                     <ul>
                         <li class="webinar-tile">
                             <div class="flex flex-col md:flex-row">
@@ -70,7 +70,7 @@ meta:
             {%- for item in collections.ama | inFuture -%}
             {% if loop.first %}
                 <div>
-                    <h2 class="w-full">Upcoming "Ask Me Anything" Session: <span class="text-red-600 italic text-lg ml-2">{{ (item.date | countDays).text }}</span></h2>
+                    <h2 class="w-full">Upcoming "Ask Me Anything" Session: <span class="text-red-600 italic text-lg ml-2">{{ item.date.toLocaleDateString(undefined, { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' }) }}</span></h2>
                     <ul>
                         <li class="webinar-tile">
                             <div class="flex flex-col md:flex-row">


### PR DESCRIPTION
## Description

Alternative design to show the Webinar date as #407 didn't work to show a "X Days Away' counter. Can only think it's because Eleventy is a static generator, so the "X Days Away" remains static after build of the site, and doesn't update.