### PR TITLE
Fixes spacetime.isSame call to ensure we show event on same day

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -59,7 +59,7 @@ module.exports = function(eleventyConfig) {
         if (posts) {
             return posts.filter((post) => {
                 const postDate = spacetime(post.data.date)
-                return postDate.isAfter(spacetime.today()) || postDate.isSame(spacetime.today())
+                return postDate.isAfter(spacetime.today()) || postDate.isSame(spacetime.today(), 'day')
             })
         } else {
             return null


### PR DESCRIPTION
## Description

Urgent fix for webinar not showing as the diff was only showing _future_ events, not same day.