### PR TITLE
security: Mention MQTT endpoint

### DIFF
--- a/src/product/security.md
+++ b/src/product/security.md
@@ -75,4 +75,6 @@ corporate website is hosted at [flowforge.com](https://flowforge.com). The
 application is served at [app.flowforge.com](https://app.flowforge.com), while
 the Node-RED instances are served from \*.flowforge.cloud.
 
+MQTT traffic is served from mqtt.flowforge.cloud.
+
 </div>

--- a/src/product/security.md
+++ b/src/product/security.md
@@ -75,6 +75,6 @@ corporate website is hosted at [flowforge.com](https://flowforge.com). The
 application is served at [app.flowforge.com](https://app.flowforge.com), while
 the Node-RED instances are served from \*.flowforge.cloud.
 
-MQTT traffic is served from mqtt.flowforge.cloud.
+MQTT traffic is served from mqtt.flowforge.cloud as MQTT over WebSockets.
 
 </div>


### PR DESCRIPTION
Our security document should explicitly mention MQTT, now it does.