### PR TITLE
fix image now showing on the blog index

### DIFF
--- a/src/blog/2023/02/flowforge-1-4-0-released.md
+++ b/src/blog/2023/02/flowforge-1-4-0-released.md
@@ -5,7 +5,7 @@ description: Deploy Node-RED to many devices quickly, and allow a staged develop
 date: 2023-02-16 14:00:00.0
 authors: ["ian-skerrett"]
 video: vbg4zTmUYjQ
-image: /blog/2023/0102/images/ff-r14-image.png
+image: ff-r14-image.png
 ---
 
 Deploy Node-RED to many devices quickly, and allow a staged development process with the latest release of FlowForge v1.4.


### PR DESCRIPTION
The image logic has recently changed and doesn't require the full path anymore. This change updates it to the new style of listing the image.