### PR TITLE
Fix blog image rendering

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -109,8 +109,6 @@ module.exports = function(eleventyConfig) {
     })
 
     eleventyConfig.addFilter("toAbsoluteUrl", function(url) {
-        console.log(url)
-        console.log(new URL(url, site.baseURL).href)
         return new URL(url, site.baseURL).href;
     })
 
@@ -131,7 +129,6 @@ module.exports = function(eleventyConfig) {
                 const hierarchyB = b.url.split('/').filter(n => n)
                 return hierarchyA.length - hierarchyB.length
             }).forEach((page) => {
-                console.log(page.url)
                 // work out ToC Hierarchy
                 // split the folder URI/URL, as this defines our TOC Hierarchy
                 const hierarchy = page.url.split('/').filter(n => n)

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -109,6 +109,8 @@ module.exports = function(eleventyConfig) {
     })
 
     eleventyConfig.addFilter("toAbsoluteUrl", function(url) {
+        console.log(url)
+        console.log(new URL(url, site.baseURL).href)
         return new URL(url, site.baseURL).href;
     })
 

--- a/src/blog.njk
+++ b/src/blog.njk
@@ -32,7 +32,7 @@ meta:
                 <div class="flex flex-col md:flex-row">
                     <div class="pr-2 md:w-1/3">
                         {% if item.data.image %}
-                        <img class="w-full h-auto" src="{{ item.url }}../images/{{item.data.image}}" />
+                        <img class="w-full h-auto" src="{{item.data.image}}" />
                         {% else %}
                         {{ item.url | generatePostSVG |safe}}
                         {% endif %}
@@ -65,7 +65,13 @@ meta:
             <a href="{{ item.url }}" class="w-full flex flex-col group hover:no-underline">
                 <div class="">
                     <time class="block text-xs mb-2" value="{{ item.date }}" class="text-gray-400">{{ item.date | shortDate }}</time>
-                    <div>{% if item.image %}<img class="w-full h-auto" src="{{item.image}}" />{% else %}{{ item.url | generatePostSVG |safe}}{% endif %}</div>
+                    <div>
+                        {% if item.data.image %}
+                        <img class="w-full h-auto" src="{{item.data.image}}" />
+                        {% else %}
+                        {{ item.url | generatePostSVG |safe}}
+                        {% endif %}
+                    </div>
                     <h3 class="mt-1 mb-0 font-medium group-hover:underline">{{ item.data.title }}</h3>
                 </div>
                 <div class="text-sm prose prose-blue md:prose-md py-1">

--- a/src/blog/2023/02/flowforge-1-4-0-released.md
+++ b/src/blog/2023/02/flowforge-1-4-0-released.md
@@ -5,7 +5,7 @@ description: Deploy Node-RED to many devices quickly, and allow a staged develop
 date: 2023-02-16 14:00:00.0
 authors: ["ian-skerrett"]
 video: vbg4zTmUYjQ
-image: ff-r14-image.png
+image: /blog/2023/02/images/ff-r14-image.png
 ---
 
 Deploy Node-RED to many devices quickly, and allow a staged development process with the latest release of FlowForge v1.4.

--- a/src/blog/2023/02/highly-available-node-red.md
+++ b/src/blog/2023/02/highly-available-node-red.md
@@ -4,7 +4,7 @@ subtitle: How mission critical use-cases can be supported through FlowForge soon
 description: Often requested features for Node-RED include HA or Highly Available
 date: 2023-02-15
 authors: ["zeger-jan-van-de-weg"]
-image: roadmap-unsplash.jpg
+image: /blog/2023/02/images/roadmap-unsplash.jpg
 ---
 
 Over the past few months we've held a lot of product discovery sessions and a topic


### PR DESCRIPTION
## Description

Noticed that og:image tile wasn't rendering for our latest blog.

Upon investigation, it's linked to how image tiles are rendered in the blog. The blogs should require absolute path, rather than relative path image pointers in the meta data.

e.g.

```
---
image: /blog/2023/02/images/ff-r14-image.png
---
```

not 
```
---
image: ff-r14-image.png
---
```

This was missed because the first/latest blog post was rendering with the relative path, but the historical blogs were not. The `og:image` also required an absolute path and assumed images stored in the top-tier `/images` folder, which has now been removed.

Verified via socialsharepreview.com that these all now work correctly:

<img width="954" alt="Screenshot 2023-02-16 at 16 25 06" src="https://user-images.githubusercontent.com/99246719/219426718-6fbbc9ed-1844-4490-8186-d5db92c0ff54.png">
