### PR TITLE
Ensure handbook.json points to the handbook nav options

### DIFF
--- a/src/handbook/handbook.json
+++ b/src/handbook/handbook.json
@@ -3,7 +3,7 @@
     "meta": {
         "title": "Handbook"
     },
-    "nav": "docs",
+    "nav": "handbook",
     "tags": [
         "handbook"
     ]


### PR DESCRIPTION
## Description

Not sure how/why I made that change, but it was in error. This reverts the handbook.json `nav` option back to `handbook`

## Related Issue(s)

Closes #422 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [-] Suitable unit/system level tests have been added and they pass
 - [-] Documentation has been updated
