### PR TITLE
fix image path within article

### DIFF
--- a/src/_includes/layouts/post.njk
+++ b/src/_includes/layouts/post.njk
@@ -30,7 +30,7 @@ layout: layouts/base.njk
             </a>
             <div class="prose">
                 <div>{% if video %}<iframe width="560" height="315" src="https://www.youtube.com/embed/{{video}}" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-                     {% elif image %}<img class="w-full h-auto" src="../images/{{image}}" />
+                     {% elif image %}<img class="w-full h-auto" src="{{image}}" />
                      {% else %}{{ page.url | generatePostSVG |safe}}{% endif %}
                 </div>
                 {{ content | safe }}


### PR DESCRIPTION
## Description

I'd checked with #421 that the image rendered at top level okay (/blog), but not within the article itself.