### PR TITLE
Link: add rel=noopener

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -130,7 +130,7 @@
                         <li class="flex"><a href="/docs">docs</a></li>
 			            <li class="flex"><a href="https://app.flowforge.com">sign in</a></li>
                         <a class="ml-2 mr-2 ff-btn ff-btn--primary uppercase text-sm" href="https://app.flowforge.com/account/create" onclick="capture('cta-join', {'position': 'header'})">Free Trial</a>
-                        <li class="flex"><a class="ff-icon--gh" href="https://github.com/flowforge" target="_blank">{% include "components/github.njk" %}</a></li>
+                        <li class="flex"><a class="ff-icon--gh" rel="noopener" href="https://github.com/flowforge" target="_blank">{% include "components/github.njk" %}</a></li>
                     </ul>
                 </nav>
             </header>


### PR DESCRIPTION
## Description

On the why: https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel/noopener

Think this was just a small oversight, but good one to add.