### PR TITLE
Remove hardcoded meta.title for docs.json

### DIFF
--- a/src/docs/docs.json
+++ b/src/docs/docs.json
@@ -1,8 +1,5 @@
 {
     "layout": "layouts/handbook.njk",
-    "meta": {
-        "title": "Docs"
-    },
     "nav": "docs",
     "tags": [
         "docs"


### PR DESCRIPTION
## Description

Had a difficult merge on Thursday, and seems as though this was re-introduced. Means that anything of the /docs pages don't have a meta.title set, and instead use the `eleventyComputed.js` `meta.title` instead.

<img width="1061" alt="Screenshot 2023-02-21 at 08 55 13" src="https://user-images.githubusercontent.com/99246719/220296143-c75121df-2e11-4675-ae61-c66fd5d637ca.png">
<img width="1054" alt="Screenshot 2023-02-21 at 08 55 18" src="https://user-images.githubusercontent.com/99246719/220296153-3670119b-67e2-4dfd-91e6-533dc95ac9a7.png">

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [-] Suitable unit/system level tests have been added and they pass
 - [-] Documentation has been updated
