### PR TITLE
Add dynamic img for tile to Twitter social cards

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -60,8 +60,10 @@
     <!-- Open Graph Image -->
     {% if image %}
     <meta property="og:image" content="{{ image | toAbsoluteUrl }}" />
+    <meta name="twitter:image" content="{{ image | toAbsoluteUrl }}" />
     {% else %}
     <meta property="og:image" content="{{ 'images/og-social-tile.jpg' | toAbsoluteUrl }}" />
+    <meta name="twitter:image" content="{{ 'images/og-social-tile.jpg' | toAbsoluteUrl }}" />
     {% endif %}
 
     {% if tags and 'posts' in tags %}
@@ -74,7 +76,6 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:description" content="" />
     <meta name="twitter:site" content="@flowforgeinc" />
-    <meta name="twitter:image" content="/images/og-social-tile.jpg" />
     {% endif %}    
 
     <script>


### PR DESCRIPTION
## Description

The Twitter cards were missed when adding `toAbsoluteUrl` in https://github.com/flowforge/website/commit/eea1ea635689ac36a66a00925d54049473579a77

## Related Issue(s)

Couldn't find the PR in which the `toAbsoluteUrl` work was added.

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [-] Suitable unit/system level tests have been added and they pass
 - [-] Documentation has been updated
