### PR TITLE
force hbspt to load prior to form

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -78,6 +78,10 @@
     <meta name="twitter:site" content="@flowforgeinc" />
     {% endif %}    
 
+    <!-- HubSpot -->
+    <script type="text/javascript" charset="utf-8" src="//js-eu1.hsforms.net/forms/embed/v2.js"></script>
+    <script type="text/javascript" id="hs-script-loader" src="//js-eu1.hs-scripts.com/26586079.js"></script>
+
     <script>
         // Intercept all injected script tags and set them to defer
         const observer = new MutationObserver(mutations => {
@@ -211,10 +215,6 @@ document.getElementById('nav-toggle').onclick = function(){
         }
     }
 </script>
-
-<!-- HubSpot -->
-<script async type="text/javascript" id="hs-script-loader" src="//js-eu1.hs-scripts.com/26586079.js"></script>
-<script async type="text/javascript" charset="utf-8" src="//js-eu1.hsforms.net/forms/embed/v2.js"></script>
 
 <!-- Google tag (gtag.js) -->
 <script async type="text/javascript" src="https://www.googletagmanager.com/gtag/js?id=G-2ZH9W82QL8"></script>


### PR DESCRIPTION
## Description

Fixes HubSpot forms (broken in #433) - the solution is detrimental to performance as I require a load of the JS upfront, but given we have a webinar in 3 hours, and we've just shouted on socials for people to sign up and no forms currently work, thought this was worth pushing in ASAP.

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [-] Suitable unit/system level tests have been added and they pass
 - [-] Documentation has been updated
