### PR TITLE
Explicitly include hubspot form each time it is used

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -76,11 +76,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:description" content="" />
     <meta name="twitter:site" content="@flowforgeinc" />
-    {% endif %}    
-
-    <!-- HubSpot -->
-    <script type="text/javascript" charset="utf-8" src="//js-eu1.hsforms.net/forms/embed/v2.js"></script>
-    <script type="text/javascript" id="hs-script-loader" src="//js-eu1.hs-scripts.com/26586079.js"></script>
+    {% endif %}
 
     <script>
         // Intercept all injected script tags and set them to defer
@@ -200,6 +196,9 @@ document.getElementById('nav-toggle').onclick = function(){
 
 <!-- Syntax Highlighting CSS -->
 <link rel="preload" href="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/themes/prism-tomorrow.min.css" as="style" onload="this.onload=null;this.rel='stylesheet'" crossorigin="anonymous" referrerpolicy="no-referrer" />
+
+<!-- HubSpot Tracking -->
+<script async type="text/javascript" id="hs-script-loader" src="//js-eu1.hs-scripts.com/26586079.js"></script>
 
 <!-- Cookie banner -->
 <script async type="text/javascript" src="/js/cc.min.js"></script>

--- a/src/_includes/layouts/post.njk
+++ b/src/_includes/layouts/post.njk
@@ -37,17 +37,19 @@ layout: layouts/base.njk
             </div>
             <div class="mt-12 pt-6 flex flex-col border-t-2">
                 <h3 class="mb-6">Sign up for updates</h3>
-                <script charset="utf-8" type="text/javascript" src="//js-eu1.hsforms.net/forms/embed/v2.js"></script>
                 <script>
-                    hbspt.forms.create({
-                        region: "eu1",
-                        portalId: "26586079",
-                        formId: "159c173d-dd95-49bd-922b-ff3ef243e90c",
-                        onFormSubmit: function($form) {
-                            capture('cta-blog-subscribe', {'position': 'article'})
-                        }
-                    });
+                    function displayHubSpotForm() {
+                        hbspt.forms.create({
+                            region: "eu1",
+                            portalId: "26586079",
+                            formId: "159c173d-dd95-49bd-922b-ff3ef243e90c",
+                            onFormSubmit: function($form) {
+                                capture('cta-blog-subscribe', {'position': 'article'})
+                            }
+                        });
+                    }
                 </script>
+                <script async type="text/javascript" charset="utf-8" src="//js-eu1.hsforms.net/forms/embed/v2.js" onload="displayHubSpotForm()"></script>
             </div>
         </div>
     </div>

--- a/src/_includes/layouts/webinar.njk
+++ b/src/_includes/layouts/webinar.njk
@@ -39,12 +39,11 @@ layout: layouts/base.njk
                 <div class="mt-6 flex flex-col">
                     <h3 class="mb-3">Register Here:</h3>
                     <script>
-                        if (hbspt) {
-                            const formId = "{{ hubspot.formId }}"
+                        function displayHubSpotForm() {
                             hbspt.forms.create({
                                 region: "eu1",
                                 portalId: "26586079",
-                                formId: formId,
+                                formId: "{{ hubspot.formId }}",
                                 onFormSubmit: function($form) {
                                     const article_title = "{{ title }}"
                                     capture('cta-webinar-register', {
@@ -54,6 +53,7 @@ layout: layouts/base.njk
                             });
                         }
                     </script>
+                    <script async type="text/javascript" charset="utf-8" src="//js-eu1.hsforms.net/forms/embed/v2.js" onload="displayHubSpotForm()"></script>
                 </div>
                 {% endif %}
                 <div class="mt-6 flex flex-col">

--- a/src/blog.njk
+++ b/src/blog.njk
@@ -50,15 +50,18 @@ meta:
             <a id="sign-up"></a>
             <h5 class="mb-0">Sign up for our monthly email updates:</h5>
             <script>
-            hbspt.forms.create({
-                region: "eu1",
-                portalId: "26586079",
-                formId: "159c173d-dd95-49bd-922b-ff3ef243e90c",
-                onFormSubmit: function($form) {
-                    capture('cta-blog-subscribe', {'position': 'primary'})
+                function displayHubSpotForm() {
+                    hbspt.forms.create({
+                        region: "eu1",
+                        portalId: "26586079",
+                        formId: "159c173d-dd95-49bd-922b-ff3ef243e90c",
+                        onFormSubmit: function($form) {
+                            capture('cta-blog-subscribe', {'position': 'primary'})
+                        }
+                    });
                 }
-            });
             </script>
+            <script async type="text/javascript" charset="utf-8" src="//js-eu1.hsforms.net/forms/embed/v2.js" onload="displayHubSpotForm()"></script>
         </div>
         {% else %}
         <li class="w-full md:w-1/3 my-2 px-2 pb-6 border-b">

--- a/src/community/newsletter.njk
+++ b/src/community/newsletter.njk
@@ -48,17 +48,19 @@ sitemapPriority: 0.9
         <div class="w-full px-2 pt-2 pb-2 mb-2 flex flex-col border-t-2 border-b-2">
             <a id="sign-up"></a>
             <h5 class="mb-0">Sign up for our monthly email updates:</h5>
-           <script charset="utf-8" type="text/javascript" src="//js-eu1.hsforms.net/forms/embed/v2.js"></script>
-<script>
-  hbspt.forms.create({
-    region: "eu1",
-    portalId: "26586079",
-    formId: "159c173d-dd95-49bd-922b-ff3ef243e90c",
-    onFormSubmit: function($form) {
-        capture('cta-blog-subscribe', {'position': 'primary'})
-    }
-  });
-</script>
+            <script>
+                function displayHubSpotForm() {
+                    hbspt.forms.create({
+                        region: "eu1",
+                        portalId: "26586079",
+                        formId: "159c173d-dd95-49bd-922b-ff3ef243e90c",
+                        onFormSubmit: function($form) {
+                            capture('cta-blog-subscribe', {'position': 'primary'})
+                        }
+                    });
+                }
+            </script>
+            <script async type="text/javascript" charset="utf-8" src="//js-eu1.hsforms.net/forms/embed/v2.js" onload="displayHubSpotForm()"></script>
         </div>
         {% else %}
         <li class="w-full md:w-1/3 my-2 px-2 pb-6 border-b">

--- a/src/contact-us.njk
+++ b/src/contact-us.njk
@@ -9,15 +9,17 @@ meta:
 <div class="container m-auto text-left max-w-4xl pb-24">
   <div class="flex justify-between items-center mb-4 md:px-4 md:-mb-0 md:px-0 md:block">
     <div class="ff-bg-light product px-4 pb-24 pt-4 md:pt-12 md:p-12 md:grid grid-cols-2">
-      <img class="hidden md:w-72 md:m-auto md:block md:mt-0" src="../images/pictograms/browser_red.png" alt="Graphic of a globe, depicting 'Connectivity'."/>
-      <script charset="utf-8" type="text/javascript" src="//js-eu1.hsforms.net/forms/embed/v2.js"></script>
+      <img class="hidden md:w-72 md:m-auto md:block md:mt-0" src="../images/pictograms/browser_red.png" alt="Graphic of a globe, depicting 'Connectivity'."/>     
       <script>
-        hbspt.forms.create({
-         region: "eu1",
-         portalId: "26586079",
-         formId: "734455e5-4cda-4329-97da-07e40cda791c"
-        });
-     </script>
+        function displayHubSpotForm() {
+          hbspt.forms.create({
+            region: "eu1",
+            portalId: "26586079",
+            formId: "734455e5-4cda-4329-97da-07e40cda791c"
+          });
+        }
+      </script>
+      <script async type="text/javascript" charset="utf-8" src="//js-eu1.hsforms.net/forms/embed/v2.js" onload="displayHubSpotForm()"></script>
     </div>
   </div>
 </div>

--- a/src/support.njk
+++ b/src/support.njk
@@ -10,14 +10,16 @@ sitemapPriority: 0.8
       <img class="hidden md:w-72 md:m-auto md:block md:mt-0" src="../images/pictograms/ticket_red.png" alt="Graphic of a globe, depicting 'Connectivity'."/>
 
       <script src="https://www.google.com/recaptcha/api.js"></script>
-      <script charset="utf-8" type="text/javascript" src="//js-eu1.hsforms.net/forms/embed/v2.js"></script>
       <script>
-        hbspt.forms.create({
-          region: "eu1",
-          portalId: "26586079",
-          formId: "74ffcab1-a984-459a-871f-5751b8d69ac2"
-        });
+        function displayHubSpotForm() {
+          hbspt.forms.create({
+            region: "eu1",
+            portalId: "26586079",
+            formId: "74ffcab1-a984-459a-871f-5751b8d69ac2"
+          });
+        }
       </script>
+      <script async type="text/javascript" charset="utf-8" src="//js-eu1.hsforms.net/forms/embed/v2.js" onload="displayHubSpotForm()"></script>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Description

Tweaks Hubspot form code to be only included on pages it's actually used.

Additionally, it sets the `async` flag, and renders the form using the onload callback so it's not page load blocking. 

Please verify this is behaving as expected locally as part of review.

## Related Issue(s)

#401 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [-] Suitable unit/system level tests have been added and they pass
 - [-] Documentation has been updated
