### PR TITLE
Pin mermaid to 9.4.0

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -286,7 +286,9 @@ module.exports = function(eleventyConfig) {
         return baseUrl+originalPath.replace(/^.\//,'')
     })
     eleventyConfig.addPlugin(require("@11ty/eleventy-plugin-rss"))
-    eleventyConfig.addPlugin(pluginMermaid);
+    eleventyConfig.addPlugin(pluginMermaid, {
+        mermaid_js_src: 'https://cdn.jsdelivr.net/npm/mermaid@9.4.0/dist/mermaid.min.js',
+    });
 
     const markdownItOptions = {
         html: true,


### PR DESCRIPTION
V10 removed the file included by the eleventy-plugin-mermaid plugin (see https://github.com/KevinGimbel/eleventy-plugin-mermaid/issues/2), shipping instead only the esm version.

This fixes Mermaid JS while the lovely @KevinGimbel cuts a new release.

## Related Issue(s)

#427 #401 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [-] Suitable unit/system level tests have been added and they pass
 - [-] Documentation has been updated
