### PR TITLE
Only include clipboard and syntax for: Blog Posts, Handbook, Docs

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -190,13 +190,6 @@ document.getElementById('nav-toggle').onclick = function(){
 <script async src="https://cdn.jsdelivr.net/npm/lite-youtube-embed@0.2.0/src/lite-yt-embed.min.js"></script>
 <link rel="preload" href="https://cdn.jsdelivr.net/npm/lite-youtube-embed@0.2.0/src/lite-yt-embed.min.css" as="style" onload="this.onload=null;this.rel='stylesheet'" crossorigin="anonymous" referrerpolicy="no-referrer" />
 
-<!-- Clipboard -->
-<link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/Primer/19.1.1/tooltips.min.css"  as="style" onload="this.onload=null;this.rel='stylesheet'" crossorigin="anonymous" referrerpolicy="no-referrer" />
-{% initClipboardJS %}
-
-<!-- Syntax Highlighting CSS -->
-<link rel="preload" href="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/themes/prism-tomorrow.min.css" as="style" onload="this.onload=null;this.rel='stylesheet'" crossorigin="anonymous" referrerpolicy="no-referrer" />
-
 <!-- HubSpot Tracking -->
 <script async type="text/javascript" id="hs-script-loader" src="//js-eu1.hs-scripts.com/26586079.js"></script>
 

--- a/src/_includes/layouts/handbook.njk
+++ b/src/_includes/layouts/handbook.njk
@@ -170,4 +170,13 @@ layout: nohero
         }
     })
 </script>
+
 {% mermaid_js %}
+
+<!-- Clipboard -->
+<link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/Primer/19.1.1/tooltips.min.css"  as="style" onload="this.onload=null;this.rel='stylesheet'" crossorigin="anonymous" referrerpolicy="no-referrer" />
+{% initClipboardJS %}
+
+<!-- Syntax Highlighting CSS -->
+<link rel="preload" href="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/themes/prism-tomorrow.min.css" as="style" onload="this.onload=null;this.rel='stylesheet'" crossorigin="anonymous" referrerpolicy="no-referrer" />
+

--- a/src/_includes/layouts/post.njk
+++ b/src/_includes/layouts/post.njk
@@ -54,3 +54,10 @@ layout: layouts/base.njk
         </div>
     </div>
 </div>
+
+<!-- Clipboard -->
+<link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/Primer/19.1.1/tooltips.min.css"  as="style" onload="this.onload=null;this.rel='stylesheet'" crossorigin="anonymous" referrerpolicy="no-referrer" />
+{% initClipboardJS %}
+
+<!-- Syntax Highlighting CSS -->
+<link rel="preload" href="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/themes/prism-tomorrow.min.css" as="style" onload="this.onload=null;this.rel='stylesheet'" crossorigin="anonymous" referrerpolicy="no-referrer" />


### PR DESCRIPTION
## Description

Moves the clipboard and syntax highlighting scripts to **only** be included on:

 - Blog Posts (post.njk)
 - Handbook & Docs (handbook.njk)

I believe these are the only places code blocks are displayed.

Places to check:

http://127.0.0.1:8080/handbook/ - handbook index
http://127.0.0.1:8080/blog/2022/12/flowforge-gcp-https-set-up/ - blog post
http://127.0.0.1:8080/docs/admin/telemetry/ - docs

## Related Issue(s)

#401 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
