### PR TITLE
seo: Set canonical for all blog posts

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -26,6 +26,8 @@
     <title>FlowForge &#x2022; DevOps for Node-RED</title>
     {% endif %}
 
+    <meta rel="canonical" href="{{ page.url }}">
+
     <!-- Browser Description -->
     {% if meta and meta.description %}
     <meta name="description" content="{{ meta.description }}">


### PR DESCRIPTION
Early on, when the blog wasn't scoped to YYYY/MM yet, we published some content. That content is now redirected to the right page, but the new ones need a canonical too.

This change is just a canon to kill a fly, but it works!

The high level effect of this change, make sure search engines know what the true content page should be.