### PR TITLE
seo: Add title element everywhere

### DIFF
--- a/src/redirect.md
+++ b/src/redirect.md
@@ -27,5 +27,6 @@ permalink: "{{ redirect.from }}"
 # The "redirect" layout just has a small html header with the meta tags that do redirection.
 layout: redirect
 skipIndex: true
+title: "You're being redirected"
 ---
 (the content can be left blank; it's entirely the frontmatter doing the work here.)


### PR DESCRIPTION
Part of the SEO changes is to have a title element on every page. This has been a bit of an uphill battle given it's been generated instead of user supplied. This commit starts with providing a specific title in the frontmatter.

The handbook repo and docs in the flowforge repo will follow.

