### PR TITLE
Group dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
         "dev:eleventy": "cross-env NODE_ENV=development ELEVENTY_ENV=development npx @11ty/eleventy --serve --quiet",
         "prod:eleventy": "npx @11ty/eleventy"
     },
-    "dependencies": {
+    "dependencies": {},
+    "devDependencies": {
         "@11ty/eleventy": "^1.0.1",
         "@11ty/eleventy-plugin-rss": "^1.1.2",
         "@11ty/eleventy-plugin-syntaxhighlight": "^4.0.0",
@@ -28,9 +29,13 @@
         "@kevingimbel/eleventy-plugin-mermaid": "^1.1.0",
         "@tailwindcss/typography": "^0.4.1",
         "autoprefixer": "^10.3.7",
+        "cross-env": "^7.0.3",
+        "del-cli": "^5.0.0",
         "eleventy-plugin-code-clipboard": "^0.0.9",
         "markdown-it-anchor": "^8.4.1",
         "markdown-it-footnote": "^3.0.3",
+        "nodemon": "^2.0.20",
+        "npm-run-all": "^4.1.5",
         "postcss": "^8.3.11",
         "postcss-cli": "^9.0.1",
         "postcss-import": "^14.0.2",
@@ -40,11 +45,5 @@
         "tailwindcss": "^2.2.17",
         "terser": "^5.9.0",
         "vanilla-cookieconsent": "^2.6.1"
-    },
-    "devDependencies": {
-        "cross-env": "^7.0.3",
-        "del-cli": "^5.0.0",
-        "nodemon": "^2.0.20",
-        "npm-run-all": "^4.1.5"
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,35 +1,11 @@
 {
-    "name": "FlowForge-Website",
+    "name": "flowforge-website",
     "version": "1.0.0",
-    "description": "",
-    "dependencies": {
-        "@flowforge/forge-ui-components": "^0.2.2",
-        "@kevingimbel/eleventy-plugin-mermaid": "^1.1.0",
-        "autoprefixer": "^10.3.7",
-        "eleventy-plugin-code-clipboard": "^0.0.9",
-        "postcss-import": "^14.0.2",
-        "seedrandom": "^3.0.5"
-    },
     "private": true,
-    "devDependencies": {
-        "@11ty/eleventy": "^1.0.1",
-        "@11ty/eleventy-plugin-rss": "^1.1.2",
-        "@11ty/eleventy-plugin-syntaxhighlight": "^4.0.0",
-        "@tailwindcss/typography": "^0.4.1",
-        "cross-env": "^7.0.3",
-        "del-cli": "^5.0.0",
-        "markdown-it-anchor": "^8.4.1",
-        "markdown-it-footnote": "^3.0.3",
-        "nodemon": "^2.0.15",
-        "npm-run-all": "^4.1.5",
-        "postcss": "^8.3.11",
-        "postcss-cli": "^9.0.1",
-        "postcss-minify": "^1.1.0",
-        "spacetime": "^6.16.3",
-        "tailwindcss": "^2.2.17",
-        "terser": "^5.9.0",
-        "vanilla-cookieconsent": "^2.6.1"
-    },
+    "description": "",
+    "keywords": [],
+    "license": "Apache-2.0",
+    "author": "Nick O'Leary",
     "scripts": {
         "clean": "npx del-cli _site && npx mkdirp _site/js",
         "start": "npm-run-all clean build:js --parallel dev:*",
@@ -44,7 +20,31 @@
         "dev:eleventy": "cross-env NODE_ENV=development ELEVENTY_ENV=development npx @11ty/eleventy --serve --quiet",
         "prod:eleventy": "npx @11ty/eleventy"
     },
-    "keywords": [],
-    "author": "Nick O'Leary",
-    "license": "Apache-2.0"
+    "dependencies": {
+        "@11ty/eleventy": "^1.0.1",
+        "@11ty/eleventy-plugin-rss": "^1.1.2",
+        "@11ty/eleventy-plugin-syntaxhighlight": "^4.0.0",
+        "@flowforge/forge-ui-components": "^0.2.2",
+        "@kevingimbel/eleventy-plugin-mermaid": "^1.1.0",
+        "@tailwindcss/typography": "^0.4.1",
+        "autoprefixer": "^10.3.7",
+        "eleventy-plugin-code-clipboard": "^0.0.9",
+        "markdown-it-anchor": "^8.4.1",
+        "markdown-it-footnote": "^3.0.3",
+        "postcss": "^8.3.11",
+        "postcss-cli": "^9.0.1",
+        "postcss-import": "^14.0.2",
+        "postcss-minify": "^1.1.0",
+        "seedrandom": "^3.0.5",
+        "spacetime": "^6.16.3",
+        "tailwindcss": "^2.2.17",
+        "terser": "^5.9.0",
+        "vanilla-cookieconsent": "^2.6.1"
+    },
+    "devDependencies": {
+        "cross-env": "^7.0.3",
+        "del-cli": "^5.0.0",
+        "nodemon": "^2.0.20",
+        "npm-run-all": "^4.1.5"
+    }
 }


### PR DESCRIPTION
## Description

Since their is no runtime, previously the build time dependencies and dependencies needed for development were all mixed up between dev and prod dependencies.

This PR simply groups them all into devDependencies, since they're all needed to build the website.
