### PR TITLE
Ensure past webinars show their images too

### DIFF
--- a/src/webinars.njk
+++ b/src/webinars.njk
@@ -130,11 +130,19 @@ meta:
                     <a href="{{ item.url }}" class="w-full flex flex-col group hover:no-underline">
                         <div class="">
                             <time class="block text-xs mb-2" value="{{ item.date }}" class="text-gray-400">{{ item.date | shortDate }}</time>
-                            <div>{% if item.image %}<img class="w-full h-auto" src="{{item.image}}" />{% else %}{{ item.url | generatePostSVG |safe}}{% endif %}</div>
+                            <div>
+                                {% if item.data.image %}
+                                <img class="w-full h-auto shadow rounded" src="{{item.data.image}}" />
+                                {% else %}
+                                {{ item.url | generatePostSVG |safe}}
+                                {% endif %}
+                            </div>
                             <h3 class="mt-1 mb-0 font-medium group-hover:underline">{{ item.data.title }}</h3>
                         </div>
                         <div class="text-sm prose prose-blue md:prose-md py-1">
-                            {{ item.data.description | excerpt | safe }}
+                            {% if item.data.description %}
+                            {{ (item.data.description | excerpt | safe) }}
+                            {% endif %}
                         </div>
                     </a>
                 </li>


### PR DESCRIPTION
## Description

**Before:**

<img width="976" alt="Screenshot 2023-02-24 at 15 51 07" src="https://user-images.githubusercontent.com/99246719/221223966-ca4e81b5-7ef9-4883-aba0-f76abe514223.png">

**After:**

<img width="955" alt="Screenshot 2023-02-24 at 15 50 46" src="https://user-images.githubusercontent.com/99246719/221223876-84378f5c-c609-4b8b-bccc-75734d2a42ed.png">