### PR TITLE
Add Past Webinar Videos

### DIFF
--- a/src/_includes/layouts/webinar.njk
+++ b/src/_includes/layouts/webinar.njk
@@ -30,6 +30,9 @@ layout: layouts/base.njk
                     {% include "components/icons/chevron-left.svg" %}
                     Back to Webinars
                 </a>
+                {% if video %}
+                <iframe width="560" height="315" class="mb-4" src="https://www.youtube.com/embed/{{video}}" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+                {% endif %}
                 <div class="prose">
                     {{ content | safe }}
                 </div>

--- a/src/webinars/2023/getting-started-nodered.md
+++ b/src/webinars/2023/getting-started-nodered.md
@@ -1,6 +1,7 @@
 ---
 title: "Introduction to Node-RED: 5 minutes to your first program"
 subtitle: Join Rob Marcer, Developer Educator at FlowForge, for a webinar on getting started with Node-RED
+video: 47EvfmJji-k
 image: /images/webinars/webinar-nr-5mins.jpg
 date: 2023-02-23
 time: 16:00 GMT (11:00 ET) 


### PR DESCRIPTION
## Description

- Add placeholder for videos on the /webinar page
- Add the YouTube video ID for yesterdays Webinar video

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [-] Suitable unit/system level tests have been added and they pass
 - [-] Documentation has been updated
