### PR TITLE
url: Make canonical a ful URL

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -24,7 +24,7 @@
     <title>FlowForge &#x2022; DevOps for Node-RED</title>
     {% endif %}
 
-    <meta rel="canonical" href="{{ page.url }}">
+    <meta rel="canonical" href="{{ page.url | toAbsoluteUrl }}">
 
     <!-- Browser Description -->
     {% if meta and meta.description %}


### PR DESCRIPTION
Relative paths aren't used in the docs, and while I think they should be supported, I'm not sure Google, or any other search engine for that matter, agrees.

See also: https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls
