### PR TITLE
Defer HubSpot chat until after page has finished loading

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -175,16 +175,30 @@ document.getElementById('nav-toggle').onclick = function(){
 
 <!-- HubSpot Tracking -->
 {% set hubspotJS %}
-// Set HubSpot Chat to wait a bit so it does not block page load
-window.hsConversationsSettings = {
-    loadImmediately: false,
-};
+// Set HubSpot Chat to wait a bit so it does not block page load if user has never started a conversation
+if (
+    window.sessionStorage?.getItem("chatInProgress") === null &&
+    window.location.hash !== "#hs-chat-open"
+) {
+    window.hsConversationsSettings = {
+        loadImmediately: false,
+    };
 
-window.addEventListener("load", (event) => {
-    setTimeout(function() {
-        window.HubSpotConversations?.widget?.load();
-    }, 1000);
-});
+    window.addEventListener("load", (event) => {
+        setTimeout(function () {
+            window.HubSpotConversations?.widget?.load();
+        }, 1500);
+    });
+}
+
+window.hsConversationsOnReady = [
+    () => {
+        window.HubSpotConversations.on("conversationStarted", () => {
+            window.sessionStorage?.setItem("chatInProgress", "true");
+        });
+    },
+];
+
 {% endset %}
 <script>{{ hubspotJS | jsmin | safe }}</script>
 <script async type="text/javascript" id="hs-script-loader" src="//js-eu1.hs-scripts.com/26586079.js"></script>

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -182,7 +182,7 @@ window.hsConversationsSettings = {
 
 window.addEventListener("load", (event) => {
     setTimeout(function() {
-        window.HubSpotConversations.widget.load();
+        window.HubSpotConversations?.widget?.load();
     }, 1000);
 });
 {% endset %}

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -174,6 +174,19 @@ document.getElementById('nav-toggle').onclick = function(){
 <link rel="preload" href="https://cdn.jsdelivr.net/npm/lite-youtube-embed@0.2.0/src/lite-yt-embed.min.css" as="style" onload="this.onload=null;this.rel='stylesheet'" crossorigin="anonymous" referrerpolicy="no-referrer" />
 
 <!-- HubSpot Tracking -->
+{% set hubspotJS %}
+// Set HubSpot Chat to wait a bit so it does not block page load
+window.hsConversationsSettings = {
+    loadImmediately: false,
+};
+
+window.addEventListener("load", (event) => {
+    setTimeout(function() {
+        window.HubSpotConversations.widget.load();
+    }, 1000);
+});
+{% endset %}
+<script>{{ hubspotJS | jsmin | safe }}</script>
 <script async type="text/javascript" id="hs-script-loader" src="//js-eu1.hs-scripts.com/26586079.js"></script>
 
 <!-- Cookie banner -->


### PR DESCRIPTION
## Description

A quick win spotted while handling #478.
Hubspot is currently responsible for **over half** the main thread execution time of the website.

<img width="923" alt="Screenshot 2023-03-01 at 16 02 43" src="https://user-images.githubusercontent.com/507155/222178393-0f06dd03-6c2e-4232-9f85-5c0e2bde5013.png">

We can configure HubSpot chat to not auto-open until _after_ the page has completed loading, improving the PageSpeed score, with minimal impact to the user.

Additionally, I've turned off the scraping of non-hubspot forms, as requested by @iskerrett.

That leaves us with:
 - HubSpot analytics on all pages
 - HubSpot chat on all pages but deferred until after the page fully loads
 - HubSpot form code only on pages with HubSpot forms

<!-- Describe your changes in detail -->

## Related Issue(s)

#401 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [-] Suitable unit/system level tests have been added and they pass
 - [-] Documentation has been updated
