### PR TITLE
Image Pipeline Speed Up for Local Dev

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -16,6 +16,8 @@ const { minify } = require("terser");
 const heroGen = require("./lib/post-hero-gen.js");
 const site = require("./src/_data/site");
 
+const DEV_MODE = process.env.ELEVENTY_RUN_MODE !== "build" // Serve or watching
+
 module.exports = function(eleventyConfig) {
     eleventyConfig.setUseGitIgnore(false); // Otherwise docs and handbook are ignored
 
@@ -219,13 +221,14 @@ module.exports = function(eleventyConfig) {
 
     // Eleventy Image shortcode
     // https://www.11ty.dev/docs/plugins/image/
+    console.info(`[11ty] Image pipeline is enabled in ${DEV_MODE ? 'dev mode' : 'prod mode'} expect a wait for first build`)
     eleventyConfig.addAsyncShortcode("image", async function imageShortcode(src, alt, widths, sizes) {
         // Full list of formats here: https://www.11ty.dev/docs/plugins/image/#output-formats
         // Warning: Avif can be resource-intensive so take care!
         let formats = ["avif", "webp", "auto"];
 
-        // Skip slow formats for serve, watch, i.e. local development
-        if (process.env.ELEVENTY_RUN_MODE !== "build") {
+        // Skip slow formats for local development
+        if (DEV_MODE) {
             formats = formats.filter((format) => !['avif', 'webp'].includes(format))
         }
 
@@ -424,8 +427,8 @@ module.exports = function(eleventyConfig) {
             }
         }
 
-        // Skip slow formats for serve, watch, i.e. local development
-        if (process.env.ELEVENTY_RUN_MODE !== "build") {
+        // Skip slow formats for local development
+        if (DEV_MODE) {
             formats = formats.filter((format) => !['avif', 'webp'].includes(format))
         }
         

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -16,7 +16,7 @@ const { minify } = require("terser");
 const heroGen = require("./lib/post-hero-gen.js");
 const site = require("./src/_data/site");
 
-const DEV_MODE = process.env.ELEVENTY_RUN_MODE !== "build" // Serve or watching
+const DEV_MODE = process.env.ELEVENTY_RUN_MODE !== "build" // i.e. serve/watch
 
 module.exports = function(eleventyConfig) {
     eleventyConfig.setUseGitIgnore(false); // Otherwise docs and handbook are ignored

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -223,6 +223,12 @@ module.exports = function(eleventyConfig) {
         // Full list of formats here: https://www.11ty.dev/docs/plugins/image/#output-formats
         // Warning: Avif can be resource-intensive so take care!
         let formats = ["avif", "webp", "auto"];
+
+        // Skip slow formats for serve, watch, i.e. local development
+        if (process.env.ELEVENTY_RUN_MODE !== "build") {
+            formats = formats.filter((format) => !['avif', 'webp'].includes(format))
+        }
+
         let file = resolvedImagePath(this.page.inputPath, src);
         let metadata = await eleventyImage(file, {
             widths: widths ? widths.concat(widths.map((w) => w * 2)) : ["auto"],
@@ -417,7 +423,12 @@ module.exports = function(eleventyConfig) {
                 },
             }
         }
-       
+
+        // Skip slow formats for serve, watch, i.e. local development
+        if (process.env.ELEVENTY_RUN_MODE !== "build") {
+            formats = formats.filter((format) => !['avif', 'webp'].includes(format))
+        }
+        
         // Handle both relative to post and root
         const widths = [650] // width of blog prose
         const imgOpts = {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "author": "Nick O'Leary",
     "scripts": {
         "clean": "npx del-cli '_site/' && npx mkdirp '_site/js'",
-        "clean:dev": "npx del-cli '_site/!(img)' && npx mkdir '_site/js'",
+        "clean:dev": "npx del-cli '_site/!(img)' && npx mkdirp '_site/js'",
         "start": "npm-run-all clean:dev build:js --parallel dev:*",
         "build": "cross-env NODE_ENV=production npm-run-all clean build:js handbook docs --parallel prod:*",
         "build:js": "terser -c -m -o _site/js/cc.min.js node_modules/vanilla-cookieconsent/dist/cookieconsent.js src/js/cookies.js",

--- a/package.json
+++ b/package.json
@@ -7,8 +7,9 @@
     "license": "Apache-2.0",
     "author": "Nick O'Leary",
     "scripts": {
-        "clean": "npx del-cli _site && npx mkdirp _site/js",
-        "start": "npm-run-all clean build:js --parallel dev:*",
+        "clean": "npx del-cli '_site/' && npx mkdirp '_site/js'",
+        "clean:dev": "npx del-cli '_site/!(img)' && npx mkdir '_site/js'",
+        "start": "npm-run-all clean:dev build:js --parallel dev:*",
         "build": "cross-env NODE_ENV=production npm-run-all clean build:js handbook docs --parallel prod:*",
         "build:js": "terser -c -m -o _site/js/cc.min.js node_modules/vanilla-cookieconsent/dist/cookieconsent.js src/js/cookies.js",
         "docs": "node scripts/copy_docs.js",


### PR DESCRIPTION
## Description

Generates a smaller number of images when using `serve` or `watch`
Keeps the image pipeline output directory (`_site/img`) around during `serve` or `watch`

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [-] Suitable unit/system level tests have been added and they pass
 - [-] Documentation has been updated
