### PR TITLE
Add live reload for CSS & JS

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -39,6 +39,11 @@ module.exports = function(eleventyConfig) {
     // Watch content images for the image pipeline
     eleventyConfig.addWatchTarget("src/**/*.{svg,webp,png,jpeg,gif}");
 
+    eleventyConfig.setServerOptions({
+        // Additional files to watch that will trigger server updates
+        watch: ["_site/**/*.css", "_site/**/*.js"],
+    })
+
     // Custom filters
     eleventyConfig.addFilter("head", (array, n) => {
         if( n < 0 ) {


### PR DESCRIPTION
## Description

Eleventy 2.0 removed live reload for CSS/JS by default, this adds it back in. (Thanks @Pezmc)

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [-] Suitable unit/system level tests have been added and they pass
 - [-] Documentation has been updated
