### PR TITLE
Only load HubSpot after first interaction with the page

### DIFF
--- a/src/_includes/hubspot.js
+++ b/src/_includes/hubspot.js
@@ -13,7 +13,9 @@ if (
             console.log(event)
             if (loaded) return
             loaded = true
-            window.HubSpotConversations?.widget?.load()
+            setTimeout(() => {
+                window.HubSpotConversations?.widget?.load()
+            }, 1)
         }
 
         window.addEventListener("mousemove", loadHubSpotChat, { once: true })

--- a/src/_includes/hubspot.js
+++ b/src/_includes/hubspot.js
@@ -1,0 +1,30 @@
+// Set HubSpot Chat to wait a bit so it does not block page load if user has never started a conversation
+if (
+    window.sessionStorage?.getItem("chatInProgress") === null &&
+    window.location.hash !== "#hs-chat-open"
+) {
+    window.hsConversationsSettings = {
+        loadImmediately: false,
+    }
+
+    window.addEventListener("load", (event) => {
+        let loaded = false
+        function loadHubSpotChat(event) {
+            console.log(event)
+            if (loaded) return
+            loaded = true
+            window.HubSpotConversations?.widget?.load()
+        }
+
+        window.addEventListener("mousemove", loadHubSpotChat, { once: true })
+        window.addEventListener("scroll", loadHubSpotChat, { once: true })
+    })
+}
+
+window.hsConversationsOnReady = [
+    () => {
+        window.HubSpotConversations.on("conversationStarted", () => {
+            window.sessionStorage?.setItem("chatInProgress", "true")
+        })
+    },
+]

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -194,32 +194,7 @@ document.getElementById('nav-toggle').onclick = function(){
 <link rel="preload" href="https://cdn.jsdelivr.net/npm/lite-youtube-embed@0.2.0/src/lite-yt-embed.min.css" as="style" onload="this.onload=null;this.rel='stylesheet'" crossorigin="anonymous" referrerpolicy="no-referrer" />
 
 <!-- HubSpot Tracking -->
-{% set hubspotJS %}
-// Set HubSpot Chat to wait a bit so it does not block page load if user has never started a conversation
-if (
-    window.sessionStorage?.getItem("chatInProgress") === null &&
-    window.location.hash !== "#hs-chat-open"
-) {
-    window.hsConversationsSettings = {
-        loadImmediately: false,
-    };
-
-    window.addEventListener("load", (event) => {
-        setTimeout(function () {
-            window.HubSpotConversations?.widget?.load();
-        }, 1500);
-    });
-}
-
-window.hsConversationsOnReady = [
-    () => {
-        window.HubSpotConversations.on("conversationStarted", () => {
-            window.sessionStorage?.setItem("chatInProgress", "true");
-        });
-    },
-];
-
-{% endset %}
+{% set hubspotJS %}{% include "hubspot.js" %}{% endset %}
 <script>{{ hubspotJS | jsmin | safe }}</script>
 <script async type="text/javascript" id="hs-script-loader" src="//js-eu1.hs-scripts.com/26586079.js"></script>
 


### PR DESCRIPTION
## Description

It seems that "time to interactive" still counts scripts that are deferred to after page load

> If after a long task is executed completely and there is an idle window for 5 seconds, or the main thread only runs a short task within that 5 seconds, then the webpage is considered interactive, and the time to Interactive is the time taken for this to happen.

Loading HubSpot is not considered a "short task" as it takes longer than 50ms, so will always count against the page load, this a 1.5s delay, is hurting the score (though it was ensuring it runs as a non-main-thread task).

Waiting for user interaction, _might_ trick lighthouse into not loading this script, which is important as it affects the PageSpeed score.

## Related Issue(s)

#401 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [-] Suitable unit/system level tests have been added and they pass
 - [-] Documentation has been updated
