### PR TITLE
Update gitignore for Website & Handbook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 .DS_Store
 _site
 node_modules
-src/handbook
+src/handbook/media
 src/docs/*
 !src/docs/docs.json
 

--- a/src/handbook/.gitignore
+++ b/src/handbook/.gitignore
@@ -1,3 +1,0 @@
-.DS_Store
-.github/scripts/node_modules
-.github/scripts/package-lock.json

--- a/src/handbook/company/strategy.md
+++ b/src/handbook/company/strategy.md
@@ -1,0 +1,104 @@
+---
+originalPath: company/strategy.md
+updated: 2022-11-23 17:31:41 +0100
+---
+### Strategy
+
+> We will only be successful if the whole Node-RED community is successful.
+
+Our company strategy has three parts:
+
+ - Drive the growth and success of the [Node-RED](https://nodered.org) project
+ - Build a platform that becomes the standard way of running Node-RED at any scale
+ - Build an inclusive, high-performance team
+
+#### Drive the growth and success of the Node-RED project
+
+Node-RED is at the core of what we do. It is the reason the company exists. Our
+success is fed by the success of the core project. Node-RED enables tens of
+thousands to create and maintain workflows and logic of both physical devices
+and digital services. Ensure their effectiveness grows, while new users are
+introduced to Node-RED is vital to the success of FlowForge.
+
+FlowForge will drive the Node-RED project through:
+
+ - **Deliver features** to the core of Node-RED that are stable and provide value to the community
+ - **Actively participate** in the community to establish a positive reputation and level of engagement
+ - **Be model citizens** for the open governance of the project. Our activities that impact the core are discussed and developed in the open.
+ - **Establish close relationships** with other stakeholders of the project - those who have their own commercial interest in the success of the project. Encourage participation and engagement in the core project.
+ - **Driving adoption** of Node-RED through our advocacy and our actions.
+
+#### Become the standard way of running any Node-RED at any scale
+
+There's a wide range of deployment scenarios and FlowForge aims to build a
+platform to help each of them to be successful. FlowForge will solve challenges
+unsolved by Node-RED and push Low-Code beyond the capabilities of Node-RED.
+
+Firstly, team collaboration. Allowing Flows to be developed by multiple
+individuals, ensuring quality and correctness. Push the boundaries of Low-Code
+to allow more people to collaborate.
+
+Secondly, Node-RED is deployed in many different environments. FlowForge will allow
+everyone to achieve the best results whatever the execution context.
+
+We believe these two points will make FlowForge synonymous with Node-RED, and
+make it attractive to individual users as well as Enterprises. Value offered
+will increase exponentially as the platform scales to teams of developers and
+larger deployment scenarios.
+
+#### Build an inclusive, high-performance team
+
+As a new company that starts small but aspires to grow, we need to ensure that growth is well managed, sustainable and rewarding.
+
+Our [values](../company#values) help shape the culture we want to build, both inside the company and beyond.
+
+### Strategic Initiatives
+
+#### 2022
+
+There are four pillars of the product we're investing in:
+1. Provide the best Node-RED experience.
+1. Enable users to run Node-RED at the edge.
+1. Enable teams to collaborate when working with Node-RED.
+1. Meet the compliance needs of the enterprise.
+
+The [product plan](../product/plan.md) goes into this in more depth.
+Check out our [roadmap](https://github.com/orgs/flowforge/projects/5) for on what we're pursuing in the next few releases.
+
+Furthermore, we will continue our involvement with the Node-RED community.
+
+
+1. **Provide technical leadership and direction** - This includes
+    - Flow Testing Framework
+    - Runtime Hooks on Deploy path
+
+2. **Improve the node ecosystem**. This includes:
+    - **node-red-dev** - CLI tool for node developers to help them produce higher quality nodes
+    - Integrating **node-red-dev** into the Flow Library to provide node scorecards
+
+3. **Improve the Getting Started experience** - update and expand the getting started docs to provide a more consistent and broader range of options/platforms to run on.
+
+4. **Community events**
+    - Establish a regular Node-RED virtual meetup for community members to share what they are doing with Node-RED.
+    - Work towards a global Node-RED Con 2022 event in conjunction with the Node-RED Japan User Group. Build on the success of the 2021 event's global track, to make it bigger, with more EU/US-centric content and timezone accessibility
+
+### Key metrics
+
+At FlowForge we're engaged in many initiatives to grow our offering and assess
+product market fit. Currently we're measuring 2 key metrics which serve as
+heuristic for company wide success.
+
+#### Installed Platforms
+
+FlowForge is the key product we're verifying in the market currently. Each
+platform installed and running shows value is delivered to customers. Through
+telemetry we know the number of instances that reported their unique instance ID.
+
+Other than the number of unique instances reporting on telemetry the last 7 days
+we measure the number of managed instances of Node-RED through FlowForge. This
+is the sum of projects and devices.
+
+Telemetry collection is opt-in, and dependant on an internet connection. As such
+it's anticipated to under report the true number of FlowForge managed instances.
+
+Target growth for this metric is 10% week over week.

--- a/src/handbook/development/contributing.md
+++ b/src/handbook/development/contributing.md
@@ -1,0 +1,53 @@
+---
+originalPath: development/contributing.md
+updated: 2022-10-13 13:05:31 +0200
+---
+## Contributing
+
+### Coding Best Practices
+
+#### Linting
+
+All code repositories adopt our standard linting rules found in the [flowforge/.github repository](https://github.com/flowforge/.github/blob/main/.eslintrc).
+
+We use [StandardJS](https://standardjs.com/), with one exception - 4 spaces not 2.
+
+If you're using VSCode, then we recommend using the [ESLint extenstion](https://github.com/Microsoft/vscode-eslint) and setting `all` for the `Eslint › Code Actions On Save: Mode` setting:
+
+<img width="429" alt="ESLint - Action on Save" src="../images/eslint_actiononsave.png">
+
+In the case of working with `vue` or `njk` files (found in the [frontend](https://github.com/flowforge/flowforge/tree/main/frontend) and [website](https://github.com/flowforge/website) repositories), then you can add `vue` and `njk` to the `Eslint: Probe` setting in order to enable auto-formatting on save for these file types.
+
+<img width="478" alt="ESLint - Probe" src="../images/eslint_probe.png">
+
+### Git Best Practices
+
+### Committing
+
+Take care when adding files to a commit. It's easy just to `git add -A` (i.e. add all local changes to a commit) but this can result in commits and PRs being clogged with excessive changes that aren't linked to the actual issue/feature at hand.
+
+Take your time when committing files. Review each file carefully and ensure what you're adding to a commit is relevant and necessary.
+
+#### Git Commit Messages
+
+- Capitalise the first letter, no trailing dot, 72 chars or less.
+- First line should be an imperative/present tense, e.g. `Change` (not `Changed` or `Changes`)
+- Do not include the issue number in the first line, this means that commit message are then suitable to include in a changelog as-is.
+- Second line should either be blank, or reference to an issue/PR using one of the GitHub recognised keywords, e.g. `closes #...` `fixes #...` `part of #...`
+- The remainder should be any further narrative that is needed. Wrapped at 72 chars.
+
+#### Branching vs. Forking
+
+Commits should never be pushed directly to `main`. Instead, branch or fork from the relevant branch (most likely `main`) and work from there.
+
+It is preferred that new work be added on a branch (rather than in a forked repository), although this is not enforced. Branch names should be short, informative, and if directly linked to a single issue number, reference such issue number, e.g. `29-issue-summary`.
+
+Once code is merged, please close any related branches in order to keep the repository tidy.
+
+#### Pull Requests
+
+PRs, when opened, should have at least one reviewer assigned, and a consequent review approved, before any merge takes place. If a PR is opened for review/discussion purposes, this PR should be set to `draft` state.
+
+When merging a PR, you should choose the "Merge pull request" option. There is no need to rebase or squash the PR commits.
+
+When conducting a PR review, if you are the last (or only) reviewer and all reviews (including your own) are approvals, unless there is a comment from the author stating otherwise, you are free to conduct the merge. Otherwise, leave the merge to the author of the PR, or a future reviewer.

--- a/src/handbook/development/packaging.md
+++ b/src/handbook/development/packaging.md
@@ -1,0 +1,187 @@
+---
+originalPath: development/packaging.md
+updated: 2022-11-24 22:12:28 +0000
+---
+# FlowForge Packaging Guidelines
+
+This section describes the requirements we have for all GitHub repositories,
+and npm modules we maintain.
+
+To help ensure all of the requirements are met, an issue should be raised in
+[`flowforge/admin`](https://github.com/flowforge/admin/issues/new/choose) using
+the `New Repository Checklist` and then worked through.
+
+## Github projects
+
+### Naming
+
+- Flow Forge Components should start with `flowforge-`
+- If a Node-RED plugin/node should start with `flowforge-nr-`
+- Installers or Orchestration projects are named without the leading `flowforge-` e.g. `installer` or `helm`
+
+### Settings
+
+- A rule should be added under the projects `settings/branches` to prevent pushing directly to the `main` branch
+
+### Content
+
+All Git Repositories must contain the following files:
+
+ - `README.md`
+ - `LICENSE`
+
+### Linting
+
+All code repositories should adopt our standard linting rules by copying the
+`.eslintrc` from the [flowforge/.github repository](https://github.com/flowforge/.github/blob/main/.eslintrc).
+
+If a repository has any additional requirements for linting, such as handling Vue
+code, then additional plugins can be added.
+
+We use [StandardJS](https://standardjs.com/), with one exception - 4 spaces not 2.
+
+### Notifications
+
+Repositories should be added to the appropriate Slack channel. For core code repositories,
+this would be in the `#gh-flowforge` channel.
+
+To create a subscription, go to that channel and type the message:
+
+```
+/github subscribe flowforge/NAME-OF-REPO comments reviews
+```
+
+This will subscribe to any notifications covering: `issues`, `pulls`, `commits`, `releases`, `deployments`, `comments` and `reviews`.
+
+### Workflows
+
+#### Project Automation
+
+All code repositories must have the Project Automation workflow added. This is done
+by adding [`.github/workflows/project-automation.yml`](https://github.com/flowforge/flowforge/blob/main/.github/workflows/project-automation.yml).
+This workflow will ensure any opened issues are automatically added to the [Product board](https://github.com/orgs/flowforge/projects/3) where it can be triaged and prioritised.
+
+#### Release Publish
+
+For any repositories that contain modules to be published to npm, they should also
+have a copy of [`.github/workflows/release-publish.yml`](https://github.com/flowforge/flowforge/blob/main/.github/workflows/release-publish.yml).
+
+This workflow will publish to npm whenever the repository is tagged with a `vX.Y.Z` format
+tag.
+
+Note that each repository may have slightly different pre-publish requirements - for
+example if there is a build step or not. You may need to customise the workflow
+to match what is needed.
+
+#### Private Repositories
+
+For *private* repositories, you will also need to add a Repository Secret as
+they cannot access the organisation-wide secret we have in place.
+
+1. Generate a [Personal Access Token](https://github.com/settings/tokens) with
+   `repo, write:org` scope.
+
+2. Add it as a Repository Secret to the Private Repo (https://github.com/flowforge/<repo-name>/settings/secrets/actions)
+   with the name `PROJECT_ACCESS_TOKEN`
+
+### Labels
+
+We have a standard set of labels that should be applied to all repositories. This
+ensures we have a consistent approach to planning and tracking of work.
+
+ - Type: `epic`, `story`, `task`, `bug`
+ - Sizing: `1`, `2`, `3`, `5`, `8`, `13`
+ - Area: `area:docs`, `area:db`, `area:migration`, `area:frontend`, `area:api`, `area:device`
+ - Priority: `priority:high`, `priority:medium`, `priority:low`
+ - Status: `blocked`
+ - Product Scope: `scope:devices`, `scope:enterprise`, `scope:node-red`, `scope:collaboration`
+ - Other: `good first issue`, `upstream`, `needs-triage`
+
+The labels are synchronized across the repositories via a GitHub Action in the [`.github`](https://github.com/flowforge/.github)
+repository.
+ 
+New repositories must be added to the list in [`flowforge-repositories.yml`](https://github.com/flowforge/.github/blob/main/flowforge-repositories.yml),
+and then the [Synchronize Labels](https://github.com/flowforge/.github/actions/workflows/sync-labels.yml) action manually run.
+ 
+## NPM packages
+
+### Naming
+
+- All packages should be scoped to `@flowforge`
+
+Node-RED plugins should start with `nr-` e.g.
+ - @flowforge/nr-storage
+ - @flowforge/nr-auth
+
+Flow Forge plugins should start with `forge-` e.g.
+
+ - @flowforge/forge-driver-localfs
+ - @flowforge/forge-driver-docker
+ - @flowforge/forge-driver-k8s
+
+### Content
+
+The `package.json` must contain the following keys
+
+ - description
+ - repository
+     ```
+     "repository": {
+        "type": "git",
+        "url": "git+https://github.com/flowforge/flowforge.git"
+    },
+    ```
+ - homepage
+    ```
+    "homepage": "https://github.com/flowforge/flowforge#readme",
+    ```
+ - bugs
+    ```
+    "bugs": {
+        "url": "https://github.com/flowforge/flowforge/issues"
+    },
+    ```
+ - license
+   - Apache-2.0
+   - SEE LICENSE IN ./LICENSE
+ - author
+    ```
+    "author": {
+        "name": "FlowFlow Inc."
+    },
+    ```
+ - engines
+    ```
+    "engines": {
+      "node": ">=16.x"
+    }
+    ```
+
+### Package Version Numbering
+
+Package numbers should follow the Semantic Versioning Scheme as laid out on [semver.org](https://semver.org/).
+
+Each component will stay in step with the core flowforge/flowforge release numbering for `major.minor` but will increment their own `fix` values as needed. e.g. On release of v0.2.0 all components will tag and release v0.2.0, but can independently release v0.2.1 as needed.
+
+Major and minor releases will follow the schedule laid out in the [Cadence](index.md#cadence) section of the handbook.
+
+A Fix release can be made at any time, depending on the best judgement of the engineer making the fix but requires a review by another team member.
+
+The process for making a release is documented [here](./release.md).
+
+
+### Adding NPM packages to Stacks
+
+As we build more FlowForge specific nodes we will need to add these to the Stacks
+
+#### Localfs
+
+Currently bundled packages for the localfs driver need to be added to the [flowforge-nr-launcher](https://github.com/flowforge/flowforge-nr-launcher) `package.json`  and the path to the node needs to be added to the `nodesDir` array in the `lib/lancher.js` file (around line 70). This will be updated in the next release to be controlled by the [flowforge-driver-localfs](https://github.com/flowforge/flowforge-driver-localfs) project
+
+#### Docker
+
+Any nodes or themes should be added to the `package.json` in `node-red-container/` directory of the [docker-compose](https://github.com/flowforge/docker-compose) project
+
+#### K8s
+
+Any nodes or themes should be added to the `package.json` in `node-red-container/` directory of the [helm](https://github.com/flowforge/helm) project

--- a/src/handbook/development/release.md
+++ b/src/handbook/development/release.md
@@ -1,0 +1,125 @@
+---
+originalPath: development/release.md
+updated: 2022-12-23 16:26:38 +0000
+---
+# Release Process
+
+There are two processes, one for major/minor point releases. The second for patch
+releases.
+
+## Major/minor point releases
+
+### Setup
+
+ - Decide who will be Release Manager for this release. For Major/Minor releases this should be shared across the whole team to prevent it becoming a single point of failure. For Fix releases it can be the developer committing the fix.
+ - Create a Release checklist issue using the [Release Checklist template](https://github.com/flowforge/admin/issues/new?assignees=&labels=&template=release.md&title=Release%3A)
+ - Assign the issue to the Release Manager
+ - Ensure you have the following installed on your machine:
+    - git command-line tools.
+    - [GitHub client](https://github.com/cli/cli)
+    - [jq](https://stedolan.github.io/jq/download/)
+    - [yq](https://mikefarah.gitbook.io/yq/#install)
+ - Ensure you're machine is authenticated with the GitHub client: `gh auth login`
+ - Ensure you are able to access the FlowForge repositories using the git cli without being prompted for a password: `ssh -T git@github.com`
+ - When we are ready to start the release process the Release Manager should start a Slack Huddle in #dev and keep that open until the release is completed.
+
+### Unmanaged Repositories
+
+Not all repositories are covered by the release automation and must be published
+separately. This is typically done by the development team in the build up to the
+full release.
+
+The Release Manager should verify the following repositories are up to date and
+have been published as needed.
+
+ - [`flowforge/usage-ping-collector`](https://github.com/flowforge/usage-ping-collector)
+ - [`flowforge/forge-ui-components`](https://github.com/flowforge/forge-ui-components)
+ - [`flowforge/flowforge-device-agent`](https://github.com/flowforge/flowforge-device-agent)
+ - [`flowforge/flowforge-nr-theme`](https://github.com/flowforge/flowforge-nr-theme)
+ - [`flowforge/flowforge-nr-project-nodes`](https://github.com/flowforge/flowforge-nr-project-nodes)
+ - [`flowforge/flowforge-nr-persistent-context`](https://github.com/flowforge/flowforge-nr-persistent-context)
+
+Refer to the section [Unmanaged Releases](#unmanaged-releases) for releasing these.
+
+### Steps
+
+ - Checkout the `flowforge/admin` repository if you do not already have it.
+    - Ensure you have the latest with a `git pull`.
+ - In the *parent* directory to where you have the `admin` checked out, run:
+   
+        ./admin/checkout-release 0.x.y
+   
+   This will create a directory called `release-0.x.y` and checkout all of the releasable
+   repositories under it.
+
+   NOTE: If you do not have a global git configuration, you will need to set `user.name` and `user.email`
+   in each of those repositories.
+
+ - Within the release directory run:
+   
+        cd release-0.x.y
+        ../admin/prepare-release 0.x.y
+   
+   This will check all of the repositories are ready to be released, update
+   their `package.json` files to reflect the new version (including cross-package
+   dependencies) and update the CHANGELOG files.
+
+   It will then raise PRs against each repository with these changes in.
+- Do not panic when you see "All jobs have failed" for the `flowforge/flowforge` Release PR. 
+      This is due to the repo pointing to newer versions of other packages which have not yet been published to npm.
+
+ - Follow through the current release checklist in [`flowforge/admin`](https://github.com/flowforge/admin/issues) in the order they are listed.
+   Each PR will need to be reviewed, merged and tagged taking care to verify each one has been published before moving to the next.
+   Some steps will also require you to pause and re-run tests before continuing.
+   Updated packages will be automatically published to npm by our GitHub actions.  You can check the publish status of these as follows:
+    - Track the "Release Published" action on the GH repository
+    - Keep an eye on npmjs.org page for each package
+    - Watch for bot notifications in the [#gh-flowforge](https://flowforgeworkspace.slack.com/archives/C02UR3MBA1J) Slack channel (NOTE: the notifications can take quite a while to appear in the channel)
+ - Once all the node module components have been built and published to npm the `installer`, `helm` and `docker-compose` components can be updated and tagged.
+ - Run [staging CI pipeline publish](https://github.com/flowforge/CloudProject/actions/workflows/build-kube.yml), to ensure staging is running the latest release.
+
+### Next Steps
+
+ - As much as possible of the previous steps should be converted into a CI Pipeline making use of GitHub Actions.
+
+## Patch releases
+
+Patch releases are done as needed and have a much lighter process to allow
+fixes to be released quickly.
+
+The core `flowforge` repository has some automation in place to help with this process.
+Until that is rolled out across the other repositories, some of the backporting work
+must be done manually.
+
+ - Changes must first be PR'd to the `main` branch and reviewed in the normal manner.
+ - Before merging, the PR should have the label `backport` added.
+ - If in `flowforge/flowforge`, when the PR is merged, an automation will run to create a new PR that backports
+   the change to the maintenance branch. Otherwise, the backport PR must be manually created.
+ - The backport PR must be reviewed and merged in the normal manner.
+ - Once all of the required backport PRs are merged, raise a PR on the `maintenance` branch
+   to update the version and `CHANGELOG.md` file with suitable details.
+ - Create the GitHub release with the appropriate `vX.Y.Z` tag.
+
+Finally, create two change request issues in the admin repo, one for staging and
+one for production to upgrade to the latest version.
+
+### Unmanaged Releases
+
+The unmanaged repositories listed above have a simpler release process.
+
+1. Make announcement in #dev so team is aware
+1. Check that all changes have been merged to main
+1. Update package.json version number
+1. Run the `generate-changelog` script from `flowforge/admin` repository. This
+   generates a list of the PRs merged since the last tagged release. Note: this
+   script require the `gh` cli to be installed and logged in.
+   Update CHANGELOG.md with the output of the script.
+1. Open a new PR to merge the package.json and CHANGELOG.md changes - get it merged
+1. Tag new release in GitHub with the appropriate version number eg `v0.1.1`. Copy the CHANGELOG update into the description.
+1. Once the release is created, the GitHub Action will take care of publishing to NPM. Check the action to ensure it completes.
+
+## Launch Lunch
+
+To celebrate the launch of a new version of FlowForge, we organize a lunch on
+the release day. Each team member is encouraged to order a lunch (Expensable up
+to 25$ per launch) and join a social lunch zoom call.

--- a/src/handbook/development/security.md
+++ b/src/handbook/development/security.md
@@ -1,0 +1,56 @@
+---
+originalPath: development/security.md
+updated: 2022-08-04 17:05:04 +0100
+---
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please report any vulnerabilities discovered in FlowForge products to security@flowforge.com.
+
+We will endeavour to acknowledge and fix any reported vulnerabilities ASAP based
+on its severity and assessed impact to our users.
+
+## Bug Bounties
+
+At our sole discretion, we offer rewards for responsibly disclosed issues according
+to their severity.
+
+Please note the following are general guidelines and any reward decisions are up
+to the discretion of FlowForge. We keep these reward levels under review to ensure
+they provide a fair reflection of the issues being reported.
+
+
+Low   | Medium   | High   | Critical
+------|----------|--------|----------
+$128  | $256     | $512   | $1024
+
+
+Multiple reports of the same issue manifesting in different ways will be treated
+as a single report.
+
+The quality of bug report will also impact any ultimate reward decision.
+
+### Sample criteria
+
+The following are examples of the types of bug for each severity. It is not
+definitive and each reported bug will be considered on its own merits.
+
+*Critical Severity Bugs*
+
+ - SQL Injection
+ - Remote Code Execution
+ - Privilege Escalation
+
+*High Severity Bugs*
+
+ - Cross-Site Request Forgery
+ - Information leaks of user data
+
+*Medium Severity Bugs*
+
+ - Information leaks of non-user data
+
+*Low Severity Bugs*
+
+ - Exposure of any integer resource IDs (primary keys in our database)

--- a/src/handbook/development/staging.md
+++ b/src/handbook/development/staging.md
@@ -1,0 +1,67 @@
+---
+originalPath: development/staging.md
+updated: 2022-11-24 12:11:19 +0100
+---
+# Staging Environment
+
+We have a staging environment running on AWS which is a scaled down replica of
+our managed FlowForge offering, with a separate domain. Staging URL and sign in
+details can be found in the Developer Vault in 1Password.
+
+## AWS Account
+
+It uses a separate AWS account ending in ..9937
+
+Ben or ZJ can provision a user account for this account.
+
+The services are running in EU-West-1.
+
+## Nodes
+
+The staging environment uses one node running on a t2.small for the management
+app and a pair of t2.small nodes for the projects cluster. t2.small is the
+smallest instance that can be used with EKS.
+
+## Email
+
+Amazon SES is setup on staging however it is still running in sandbox mode which means only verified address & domains can RECEIVE emails from it, this is currently limited to flowforge.com email addresses.
+
+There is no intention to move this from sandbox as this helps to limit access to staging.
+
+If you need to use another email address with staging then you should verify the address through SES in the AWS Console.
+
+## Deployment
+
+Currently there is no auto deployment to staging, this should be rectified in the future so that staging is running the code in the main branches  of the respective repos.
+
+## Using staging
+
+When setting up a team you'll need to enter billing details. For credit card
+details, use [the Stripe mock data](https://stripe.com/docs/testing#testing-interactively).
+
+## Using the FlowForge Device Agent with staging
+
+Staging uses pre-release npm packages stored in a GitHub npm repository. To be able to use these packages you will need to authenticate with the repository.
+
+You will need to create a GH Personal token
+
+1. Go to your [classic personal access tokens](https://github.com/settings/tokens)
+1. Click Generate New Token (and again pick the classic option)
+1. You will probably be prompted for 2FA now
+1. Give the token a meaningful name
+1. Pick an expiration. I went with no expiration so I don't have to do this again and I'm going to limit the scope
+1. Tick the box next to `read:packages`
+1. Click generate token button at bottom of page
+
+Store the token in your private 1Password vault
+
+Create the following .npmrc file:
+
+```
+//npm.pkg.github.com/:_authToken=ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+@flowforge:registry=https://npm.pkg.github.com/
+```
+
+where `ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxx` is the token you just generated.
+
+You need to place this in the project directory, e.g. `/opt/flowforge-device/project` or if you are running it in the dev env `flowforge-device-agent/var/project` (assume starting with `node index -d ./var -c ./var/device.yml`)


### PR DESCRIPTION
## Description

- Update the website gitignore to cover `src/handbook/media`
- Remove handbook gitignore entirely
- This unlocked a few files that, for some reason, were all being gitignored.

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)