### PR TITLE
Include Past AMA sessions in Archive

### DIFF
--- a/src/ask-me-anything/ama-nodered.md
+++ b/src/ask-me-anything/ama-nodered.md
@@ -1,6 +1,7 @@
 ---
 title: Ask Me Anything about Node-RED (March Edition)
 subtitle: Join Nick O'Leary, co-creator of Node-RED & CTO at FlowForge and Rob Marcer, Developer Educator at FlowForge, for an AMA on Node-RED
+video: P0ZfQXh
 image: /images/webinars/ama-march.jpg
 date: 2023-03-09
 time: 16:00 GMT (11:00 ET) 

--- a/src/ask-me-anything/ama-nodered.md
+++ b/src/ask-me-anything/ama-nodered.md
@@ -1,7 +1,7 @@
 ---
 title: Ask Me Anything about Node-RED (March Edition)
 subtitle: Join Nick O'Leary, co-creator of Node-RED & CTO at FlowForge and Rob Marcer, Developer Educator at FlowForge, for an AMA on Node-RED
-video: P0ZfQXh
+video: P0ZfQXh-mqM
 image: /images/webinars/ama-march.jpg
 date: 2023-03-09
 time: 16:00 GMT (11:00 ET) 

--- a/src/ask-me-anything/ask-me-anything.json
+++ b/src/ask-me-anything/ask-me-anything.json
@@ -1,6 +1,6 @@
 {
     "tags": [
-        "ama"
+        "ama", "event"
     ],
     "layout": "layouts/webinar.njk"
 }

--- a/src/handbook/marketing/webinars.md
+++ b/src/handbook/marketing/webinars.md
@@ -21,8 +21,7 @@ Hubspot will be used to collect attendee registrations.
 * Zoom will automatically send a confirmation email and a two reminder emails to all registrants.
 
 3. Create a webinar page for the website
-* Follow the templates from previous months.
-
+* Follow the templates from previous months - more details can be found [below](#creating-a-webinar-page).
 4. Create a graphic to promote the webinar
 * Follow the templates from previous months.
 
@@ -39,3 +38,38 @@ Each webinar should be available for promotion 2-4 weeks before the live date. C
 * Slack channels
 * Node-RED forums
 * FlowForge website
+
+### Creating a Webinar Page
+
+Webinar pages follow a fixed structure, you can see plenty of examples [here](https://github.com/flowforge/website/tree/main/src/webinars) in our website repository. Importantly, they must define the following properties at the top of the `.md` file:
+
+#### Properties
+
+| Property | Description
+|-|-|
+| `title` | The title of the webinar, this will also be what shows as the "title" when shared on socials
+| `subtitle` | More context on what the webinar will involve
+| `video` | Once you have an available video recording of the session, you can include the videos' YouTube id here to include the recording in the webinar's page
+| `image` | Absolute file path to the image to show for the Webinar's tile
+| `date` | The date that the webinar will take place
+| `time` | The time that the webinar will take place, in both GMT & ET
+| `duration` | How long, in minutes with the webinar last for
+| `hosts` | A list of the webinar hosts, the names need to be formatted inline with the file names found [here](https://github.com/flowforge/website/tree/main/src/_data/team)
+| `hubspot.formId` | The formId from HubSpot to handle the event registration
+
+#### Example
+
+```yml
+---
+title: "DevOps for Node-RED: An Introduction to FlowForge"
+subtitle: Join FlowForge's CTO Nick O'Leary for an introduction to FlowForge and how it provides DevOps for Node-RED.
+video: 47EvfmJji-k
+image: /images/webinars/webinar-nr-5mins.jpg
+date: YYYY-MM-DD
+time: HH:MM GMT (HH:MM ET) 
+duration: MM
+hosts: ["rob-marcer"]
+hubspot:
+    formId: <form-id>
+---
+```

--- a/src/webinars.njk
+++ b/src/webinars.njk
@@ -129,7 +129,7 @@ meta:
     {% if collections.webinar and (collections.webinar | inPast | length) > 0 %}
         <h2 class="w-full">Past Webinars</h2>
         <ul class="grid md:grid-cols-3 gap-4">
-            {%- for item in collections.webinar | inPast | reverse -%}
+            {%- for item in collections.event | inPast | reverse -%}
                 <li class="w-full my-2 pb-6 border-b">
                     <a href="{{ item.url }}" class="w-full flex flex-col group hover:no-underline">
                         <div class="">

--- a/src/webinars/webinars.json
+++ b/src/webinars/webinars.json
@@ -1,6 +1,6 @@
 {
     "tags": [
-        "webinar"
+        "webinar", "event"
     ],
     "layout": "layouts/webinar.njk"
 }


### PR DESCRIPTION
## Description

This adds a common "event" tag for the AMA and Webinar sessions which makes them accessible into a single collection. That is now the collection we loop on for the "Past Webinars" section, instead of just the webinars.

In addition to this, I've also include the video recording for the first AMA session we did, this is done by adding:

```
video: <youtube-video-id>
```

into the top of the relevant `.md` file (fyi @iskerrett) - this wasn't in the handbook, so have added that too.

## Related Issue(s)

Closes #511 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [-] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
