### PR TITLE
pricing: Try Book a demo CTA

### DIFF
--- a/src/book-demo.njk
+++ b/src/book-demo.njk
@@ -1,0 +1,25 @@
+---
+layout: layouts/nohero.njk
+title: Book a demo
+sitemapPriority: 0.8
+meta:
+    description: Book a demo to understand how FlowForge helps you achieve your goals.
+---
+
+<div class="container m-auto text-left max-w-4xl pb-24">
+  <div class="flex justify-between items-center mb-4 md:px-4 md:-mb-0 md:px-0 md:block">
+    <div class="ff-bg-light product px-4 pb-24 pt-4 md:pt-12 md:p-12 md:grid grid-cols-2">
+      <div class="hidden md:w-72 md:m-auto md:block md:mt-0">
+        {% image "./images/pictograms/browser_red.png", "Graphic of a globe, depicting 'Connectivity'.", [288] %}
+      </div> 
+      <script charset="utf-8" type="text/javascript" src="//js-eu1.hsforms.net/forms/embed/v2.js"></script>
+<script>
+  hbspt.forms.create({
+    region: "eu1",
+    portalId: "26586079",
+    formId: "0a00e010-0dde-4091-9d6e-f38679b1f4cf"
+  });
+</script>
+    </div>
+  </div>
+</div>

--- a/src/pricing.njk
+++ b/src/pricing.njk
@@ -37,7 +37,7 @@ meta:
             <div class="sm:w-6/12">
                 <h5>Self-Managed</h5>
                 <p class="mt-2">Premium features, on your own dedicated instance.</p>
-                <a class='ff-btn ff-btn--secondary uppercase' href='/contact-us' onclick="capture('cta-enterprise', {'position': 'primary'})">Contact Us</a>
+                <a class='ff-btn ff-btn--secondary uppercase' href='/book-demo'>Book a Demo</a>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Description

To provide a lower barrier to understanding FlowForge value offering, I'd like to try 'Book a Demo' as CTA.

The current implementation has a few flaws IMO though:
1. It redirects to a form where we email back a booking link
2. I'd really hoped we could get a scheduler as a pop up when clicking the Book a demo link

In terms of iteration though; I think change will get us further with one step.