### PR TITLE
pricing: Link to the roadmap

### DIFF
--- a/src/_includes/feature_lists/cloud.njk
+++ b/src/_includes/feature_lists/cloud.njk
@@ -176,7 +176,7 @@
         </li>
         <li>
             {% include "components/feature-time.svg" %}
-            <a href="/roadmap"><label>On the Roadmap</label></a>
+            <a href="/roadmap/"><label>On the Roadmap</label></a>
         </li>        
     </ul>
 </div>

--- a/src/_includes/feature_lists/cloud.njk
+++ b/src/_includes/feature_lists/cloud.njk
@@ -176,7 +176,7 @@
         </li>
         <li>
             {% include "components/feature-time.svg" %}
-            <label>On the Roadmap</label>
+            <a href="/roadmap"><label>On the Roadmap</label></a>
         </li>        
     </ul>
 </div>


### PR DESCRIPTION
As the roadmap page now exists, so I could link it on the pricing page.

Example:
![Screenshot 2023-04-04 at 15 09 14](https://user-images.githubusercontent.com/2529595/229802828-76990045-9f72-424f-9de5-d723f969de8a.png)
