### PR TITLE
Remove DEV_MODE check

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -146,9 +146,6 @@ module.exports = function(eleventyConfig) {
     })
 
     eleventyConfig.addFilter("toAbsoluteUrl", function(url) {
-        if (DEV_MODE) {
-            return url
-        }
         return new URL(url, site.baseURL).href;
     })
 


### PR DESCRIPTION
## Description

Thought this was a reliable way to check if running locally, turns out, it also flags as being in dev mode when running in production, reverting this so that the OG images added in https://github.com/flowforge/website/pull/614 work.

Merging directly without review in order to push the fix, fast