### PR TITLE
Add "content_scrolled" to PostHog's $pageleave

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -244,17 +244,24 @@ document.getElementById('nav-toggle').onclick = function(){
     /*
         Custom pageleave handler to track scroll
     */
+    // when the page first loads, how much content can the visitor see?
     const NO_SCROLL_HEIGHT = Math.min(1, (window.innerHeight + window.pageYOffset)/document.body.offsetHeight)
+    // what's the maximum amount of content they've seen so far?
     var MAX_CONTENT_VIEWED = Math.min(1, (window.innerHeight + window.pageYOffset)/document.body.offsetHeight)
 
     addEventListener("scroll", (event) => {
+        // Math.min here catches an oddity where sometimes this creeps over 1
         const contentViewed = Math.min(1, (window.innerHeight + window.pageYOffset)/document.body.offsetHeight)
+        // Have they viewed more content than they've seen prior?
         if (contentViewed > MAX_CONTENT_VIEWED) {
             MAX_CONTENT_VIEWED = contentViewed
         }
     });
 
     function emitPageLeave () {
+        // scale these value to exist between 0 and 1
+        // 0 -> Didn't scroll, just viewed the page as it loaded
+        // 1 -> Scrolled all the way to the bottom
         const scrolled = (MAX_CONTENT_VIEWED - NO_SCROLL_HEIGHT) / (1 - NO_SCROLL_HEIGHT)
         capture('$pageleave', {
             content_scrolled: scrolled

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -237,8 +237,36 @@ document.getElementById('nav-toggle').onclick = function(){
     !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
     posthog.init('{{ POSTHOG_APIKEY }}', {
         api_host:'https://eu.posthog.com',
-        bootstrap: phBootstrap
+        bootstrap: phBootstrap,
+        capture_pageleave: false
     })
+
+    /*
+        Custom pageleave handler to track scroll
+    */
+    const NO_SCROLL_HEIGHT = Math.min(1, (window.innerHeight + window.pageYOffset)/document.body.offsetHeight)
+    var MAX_CONTENT_VIEWED = Math.min(1, (window.innerHeight + window.pageYOffset)/document.body.offsetHeight)
+
+    addEventListener("scroll", (event) => {
+        const contentViewed = Math.min(1, (window.innerHeight + window.pageYOffset)/document.body.offsetHeight)
+        if (contentViewed > MAX_CONTENT_VIEWED) {
+            MAX_CONTENT_VIEWED = contentViewed
+        }
+    });
+
+    function emitPageLeave () {
+        const scrolled = (MAX_CONTENT_VIEWED - NO_SCROLL_HEIGHT) / (1 - NO_SCROLL_HEIGHT)
+        capture('$pageleave', {
+            content_scrolled: scrolled
+        })
+    }
+
+    window.addEventListener &&
+            window.addEventListener('onpagehide' in self ? 'pagehide' : 'unload', emitPageLeave)
+
+    /*
+        Get User Agent String
+    */
     const phUA = {
         "user_agent_string": window.navigator.userAgent
     }


### PR DESCRIPTION
## Description

I had raised this https://github.com/PostHog/posthog/issues/14905 with PostHog asking for this to be added to the core PostHog library, whilst it's not looking likely that'll be built anytime soon, thought I'd implement our own as I found we can _just_ disabled the `pageleave` event and then just add our own anyway and PostHog treats them identically.

This has enabled us to include a new property on the default `$pageleave` events: `content_scroll`.

To account for different screen sizes, this calculates the height of screen on load, and then generates a number between 0 and 1, depending on the _maximum_ amount that user scrolled. 

0 - No scroll, they just viewed the content available to them on page-load
1 - They scrolled all the way to the bottom.

This is implemented on `website` only at the moment, not sure we have any value for it in FlowForge itself.

It then enables us to do PostHog Insights like this:

<img width="1425" alt="Screenshot 2023-04-07 at 12 23 28" src="https://user-images.githubusercontent.com/99246719/230600890-d86f158f-e208-4334-86fd-c3f58118d790.png">

We can also have blog & docs-dedicated views, primary pages, etc. to measure engagement and scroll depth across the website, and it can be used as a target property/metric in any future A/B tests we want to conduct.

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes