### PR TITLE
Algolia Search for Handbook & Docs

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -14,4 +14,5 @@ path = "/*"
 [[plugins]]
 package = "@algolia/netlify-plugin-crawler"
   [plugins.inputs]
+  branches = ['main', '555-algolia-search']
   pathPrefix = "/handbook"

--- a/netlify.toml
+++ b/netlify.toml
@@ -10,3 +10,8 @@ publish = "_site"
 [[edge_functions]]
 function = "eleventy-edge"
 path = "/*"
+
+[[plugins]]
+package = "@algolia/netlify-plugin-crawler"
+  [plugins.inputs]
+  pathPrefix = "/handbook"

--- a/netlify.toml
+++ b/netlify.toml
@@ -15,4 +15,3 @@ path = "/*"
 package = "@algolia/netlify-plugin-crawler"
   [plugins.inputs]
   branches = ['main', '555-algolia-search']
-  pathPrefix = "/handbook"

--- a/netlify.toml
+++ b/netlify.toml
@@ -15,3 +15,4 @@ path = "/*"
 package = "@algolia/netlify-plugin-crawler"
   [plugins.inputs]
   branches = ['main', '555-algolia-search']
+  template = "hierarchical"

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -316,4 +316,21 @@ gtag('js', new Date());
 
 gtag('config', 'G-2ZH9W82QL8');
 </script>
+
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@algolia/algoliasearch-netlify-frontend@1/dist/algoliasearchNetlify.css" />
+<link
+  rel="stylesheet"
+  href="https://cdn.jsdelivr.net/npm/@algolia/autocomplete-theme-classic"
+/>
+<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/@algolia/algoliasearch-netlify-frontend@1/dist/algoliasearchNetlify.js"></script>
+<script type="text/javascript">
+  algoliasearchNetlify({
+    appId: 'KWE0727TZS',
+    apiKey: '595ee07f069991380e9c3036cfad8e5e',
+    siteId: '00f8cf60-997f-4c4d-9427-a97924358648',
+    branch: '555-algolia-search',
+    selector: 'div#algolia-search',
+    detached: false
+  });
+</script>
 </html>

--- a/src/_includes/layouts/handbook.njk
+++ b/src/_includes/layouts/handbook.njk
@@ -22,6 +22,7 @@ date: git Last Modified
 <div class="handbook ff-prose text-left pb-24" data-{{nav}}>
     <!-- Navigation -->
     <div class="border-r">
+        <div id="algolia-search" class="border-b"></div>
         <ul class="handbook-nav" data-el="navigation">
             <li class="{% if "/{{ nav }}/" === page.url %}active{% endif %}">
                 <a href="/{{ nav }}">{{ nav }}</a>

--- a/src/css/algolia-theme.css
+++ b/src/css/algolia-theme.css
@@ -1,0 +1,18 @@
+#algolia-search {
+    --aa-search-input-height: 42px;
+    --aa-input-border-color-rgb: none;
+    --aa-spacing: 12px;
+    padding-left: var(--nav-pl);
+    padding-right: var(--nav-pl);
+}
+
+#algolia-search .aa-Input {
+    font-size: 14px;
+    border: 0;
+}
+#algolia-search .aa-Autocomplete {
+    --height: 42px;
+}
+#algolia-search .aa-InputWrapperSuffix {
+    padding: 0 6px;
+}

--- a/src/css/algolia-theme.css
+++ b/src/css/algolia-theme.css
@@ -1,7 +1,9 @@
 #algolia-search {
+    @apply sticky top-0;
     --aa-search-input-height: 42px;
     --aa-input-border-color-rgb: none;
     --aa-spacing: 12px;
+    border-color: #dedede;
     padding-left: var(--nav-pl);
     padding-right: var(--nav-pl);
 }

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -3,6 +3,7 @@
 @import "./style.nohero.css";
 @import "./style.handbook.css";
 @import "./style.components.css";
+@import "./algolia-theme.css";
 @import "./roadmap.css";
 @import "../../node_modules/@flowforge/forge-ui-components/dist/forge-ui-components.css";
 @import "../../node_modules/vanilla-cookieconsent/dist/cookieconsent.css";

--- a/src/css/style.handbook.css
+++ b/src/css/style.handbook.css
@@ -21,7 +21,7 @@
         padding-top: 0.25rem;
         max-height: calc(100vh - 1.5rem);
         overflow-y: auto;
-        @apply sticky top-0;
+        @apply sticky top-12;
     }
 
     .handbook-nav-nested {

--- a/src/css/style.handbook.css
+++ b/src/css/style.handbook.css
@@ -18,7 +18,7 @@
         --nav-pl: 1rem;
         background-color: theme(colors.gray.50);
         padding-left: 0.5rem;
-        padding-top: 1.5rem;
+        padding-top: 0.25rem;
         max-height: calc(100vh - 1.5rem);
         overflow-y: auto;
         @apply sticky top-0;

--- a/src/public/robots.txt
+++ b/src/public/robots.txt
@@ -3,6 +3,10 @@
 User-agent: *
 Allow: /
 
+User-agent: Algolia Crawler
+Disallow: * 
+Allow: /handbook
+
 Host: https://flowforge.com/
 
 Sitemap: https://flowforge.com/sitemap.xml

--- a/src/public/robots.txt
+++ b/src/public/robots.txt
@@ -4,8 +4,8 @@ User-agent: *
 Allow: /
 
 User-agent: Algolia Crawler
-Disallow: * 
 Allow: /handbook
+Disallow: / 
 
 Host: https://flowforge.com/
 

--- a/src/public/robots.txt
+++ b/src/public/robots.txt
@@ -4,8 +4,7 @@ User-agent: *
 Allow: /
 
 User-agent: Algolia Crawler
-Allow: /handbook
-Disallow: / 
+Allow: /
 
 Host: https://flowforge.com/
 

--- a/src/public/robots.txt
+++ b/src/public/robots.txt
@@ -1,3 +1,5 @@
+# Algolia-Crawler-Verif: 77BE7DC6E58603CB
+
 User-agent: *
 Allow: /
 


### PR DESCRIPTION
## Description

- Utilises the free Netlify Algolia Plugin to create an index of our site on build.
- Have then added a search bar to the docs/handbook pages, although need to refine per the todo list below

https://user-images.githubusercontent.com/99246719/230742521-97b58765-a3ab-4665-8ed9-d2a59086d21b.mov

## Still todo:

- [ ] Limit contents to _just_ handbook in the handbook search
- [ ] Improved styling ([Example in docs](https://www.algolia.com/interface-demos/3a389a38-e15f-4e33-a1e6-be468d43eb51?utm_medium=page_link&utm_source=dashboard) shows OG images in the search preview, would be great if we had similar)
- [ ] Implement for /docs too (need to run on `main` in order for docs to be included in build index)
- [ ] On focus, provide a few recommendations [as per the demo too](https://www.algolia.com/interface-demos/3a389a38-e15f-4e33-a1e6-be468d43eb51?utm_medium=page_link&utm_source=dashboard)

## Related Issue(s)

Closes #555 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [-] Suitable unit/system level tests have been added and they pass
 - [-] Documentation has been updated
