### PR TITLE
misc: Refine codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,6 @@
 # Please note the _last matching rule_ is used
-# Start with a catch all
-* @ZJvandeWeg
+# Start with a catch all for the handbook
+/src/handbook/ @ZJvandeWeg
 
 /src/handbook/design @joepavitt
 /src/handbook/development @knolleary


### PR DESCRIPTION
The catch-all rule made ZJ the owner of for example all the docs too. That was an unintended side-effect of the catch-all rule in the CODEOWNERS.
