### PR TITLE
Enable the Algolia crawler on "live" branch

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -14,5 +14,5 @@ path = "/*"
 [[plugins]]
 package = "@algolia/netlify-plugin-crawler"
   [plugins.inputs]
-  branches = ['main', '555-algolia-search']
+  branches = ['main', 'live']
   template = "hierarchical"


### PR DESCRIPTION
## Description

Crawler wasn't configured to run on 'live' branch changes. Netlify triggers Algolia, netlify is triggered by `live` not `main`

## Related Issue(s)

#620

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)