### PR TITLE
Switch the search bar to use the "live" index, not "branch"

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -332,7 +332,7 @@ gtag('config', 'G-2ZH9W82QL8');
     appId: 'KWE0727TZS',
     apiKey: '595ee07f069991380e9c3036cfad8e5e',
     siteId: '00f8cf60-997f-4c4d-9427-a97924358648',
-    branch: '555-algolia-search',
+    branch: 'live',
     selector: 'div#algolia-search',
     detached: false
   });


### PR DESCRIPTION
## Description

Crawler ran successfully, but didn't realise Algolia would create a new index (it seems to do this by git branch), so needed to switch our search bar to point to this new index.

## Related Issue(s)

#620

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
