### PR TITLE
misc: Move roadmap under /product

### DIFF
--- a/src/_includes/feature_lists/cloud.njk
+++ b/src/_includes/feature_lists/cloud.njk
@@ -176,7 +176,7 @@
         </li>
         <li>
             {% include "components/feature-time.svg" %}
-            <a href="/roadmap/"><label>On the Roadmap</label></a>
+            <a href="/product/roadmap/"><label>On the Roadmap</label></a>
         </li>        
     </ul>
 </div>

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -107,7 +107,7 @@
                             <a class="flex items-center gap-2">product {% include "components/icons/chevron-down.svg" %}</a>
                             <ul>
                                 <li><a href="/features/">features</a></li>
-                                <li><a href="/roadmap/">roadmap</a></li>
+                                <li><a href="/product/roadmap/">roadmap</a></li>
                             </ul>
                         </li>
                         <li class="flex"><a href="/pricing/">pricing</a></li>

--- a/src/blog/2022/04/flowforge-accepting-customers.md
+++ b/src/blog/2022/04/flowforge-accepting-customers.md
@@ -30,4 +30,4 @@ instance to connect virtually any online service. Multiple users will have
 access to the same flows and can collaborate. Further, once Node-RED 3.0 has
 been released, the platform will provide a pain-free way to upgrade and keep
 your projects up to date. There's many more exciting features right around the
-corner on our [roadmap](https://github.com/orgs/flowforge/projects/5).
+corner on our [roadmap](/product/roadmap/)

--- a/src/handbook/company/strategy.md
+++ b/src/handbook/company/strategy.md
@@ -63,7 +63,7 @@ There are four pillars of the product we're investing in:
 1. Meet the compliance needs of the enterprise.
 
 The [product plan](../product/plan.md) goes into this in more depth.
-Check out our [roadmap](https://github.com/orgs/flowforge/projects/5) for on what we're pursuing in the next few releases.
+Check out our [roadmap](/product/roadmap/) for on what we're pursuing in the next few releases.
 
 Furthermore, we will continue our involvement with the Node-RED community.
 

--- a/src/product/roadmap.njk
+++ b/src/product/roadmap.njk
@@ -13,7 +13,7 @@ description:
 <div>
     <div class="-mt-28 text-center">
         <a href="https://github.com/orgs/flowforge/projects/5" class="inline-block ff-btn ff-btn--secondary shadow">
-            <img src="../images/github-mark.png" alt="GitHub Logo" class="github-logo">
+            <img src="../../images/github-mark.png" alt="GitHub Logo" class="github-logo">
             <span>See our entire Roadmap on GitHub</span>
         </a>
     </div>
@@ -206,9 +206,9 @@ has a headline, description, and a container for roadmap items. -->
                 reactionCount.innerHTML = `👍 <span>${reactions}</span>`;
                 voteBtn.innerHTML = `${
                     reactionCount.outerHTML
-                }<span>Vote on GitHub</span><img src="../images/github-mark.png" alt="GitHub Logo">`;
+                }<span>Vote on GitHub</span><img src="../../images/github-mark.png" alt="GitHub Logo">`;
             } else {
-                voteBtn.innerHTML = '<span>See status</span><img src="../images/github-mark.png" alt="GitHub Logo">';
+                voteBtn.innerHTML = '<span>See status</span><img src="../../images/github-mark.png" alt="GitHub Logo">';
             }
             // Append the vote button to the centered wrapper and then append the centered wrapper to the list item.
             centerWrapper.appendChild(voteBtn);

--- a/src/redirect.md
+++ b/src/redirect.md
@@ -23,6 +23,7 @@ redirects:
   - { "from": "/blog/community-news-02/", "to": "/blog/2022/03/community-news-02/" }
   - { "from": "/blog/flowforge-03-released/", "to": "/blog/2022/03/flowforge-03-released/" }
   - { "from": "/blog/2023/03/comparinig-dashboards/", "to": "/blog/2023/03/comparing-node-red-dashboards" }
+  - { "from": "/roadmap/", "to": "/product/roadmap/" }
 # The "permalink" attribute determines where the output page will be located.
 permalink: "{{ redirect.from }}"
 # The "redirect" layout just has a small html header with the meta tags that do redirection.


### PR DESCRIPTION
## Description

Clean up the root path regarding URLs and have more semantical URLs. So the roadmap is the product roadmap, and this change moves it to "/product/roadmap".

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [x] Documentation has been updated
