### PR TITLE
Switch to the webp version of the YT thumbnail

### DIFF
--- a/src/index.njk
+++ b/src/index.njk
@@ -27,7 +27,7 @@ sitemapPriority: 1.0
 {% include "components/divider-flow--default.njk" %}
 
 <div class="flex justify-center">
-    <lite-youtube videoid="K4xw09DbSdI" style="background-image: url('https://i.ytimg.com/vi/K4xw09DbSdI/hqdefault.jpg'); width: 620px; height: 360px" class="absolute -mt-10 max-w-xs max-h-48 border-4 rounded-md sm:max-w-none sm:max-h-full"></lite-youtube>
+    <lite-youtube videoid="K4xw09DbSdI" style="background-image: url('https://i.ytimg.com/vi_webp/K4xw09DbSdI/hqdefault.webp'); width: 620px; height: 360px" class="absolute -mt-10 max-w-xs max-h-48 border-4 rounded-md sm:max-w-none sm:max-h-full"></lite-youtube>
 </div>
 
 <!-- Secondary Content -->


### PR DESCRIPTION
## Description

Have updated the YT video thumbnail, but for some reason the `jpg` cache isn't refreshing, so switching to `.webp` instead.

<img width="1165" alt="Screenshot 2023-04-12 at 16 58 36" src="https://user-images.githubusercontent.com/99246719/231514868-eb57332c-e637-4cce-85cc-ee1ce76ac456.png">


## Related Issue(s)

Closes https://github.com/flowforge/content/issues/103

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
