### PR TITLE
Remove edge function definition

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -7,10 +7,6 @@ command = "npx @11ty/eleventy --quiet --watch"
 command = "npm run build"
 publish = "_site"
 
-[[edge_functions]]
-function = "eleventy-edge"
-path = "/*"
-
 [[plugins]]
 package = "@algolia/netlify-plugin-crawler"
   [plugins.inputs]


### PR DESCRIPTION
## Description

Even though we _only_ define edge functions, and do not use them anyway, I want to see if removing their definition helps with the immediate performance loss we get when deploying to Netlify, or, if Netlify just gives a few seconds of delay once a deploy is completed generally.

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
