### PR TITLE
Add "order" key for team members

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -77,6 +77,22 @@ module.exports = function(eleventyConfig) {
         return `<div style="white-space: pre-wrap;">${unescape(str)}</div>;`
     });
 
+    eleventyConfig.addFilter('dictsortBy', function(val, reverse, attr) {
+        let array = [];
+        for (let k in val) {
+            array.push(val[k]);
+        }
+
+        array.sort((t1, t2) => {
+            var a = t1[attr];
+            var b = t2[attr];
+        
+            return a > b ? 1 : (a === b ? 0 : -1); // eslint-disable-line no-nested-ternary
+        });
+
+        return array
+    });
+
     eleventyConfig.addFilter('shortDate', dateObj => {
         return spacetime(dateObj).format('{date} {month-short}, {year}')
     });

--- a/src/_data/team/ben-hardill.json
+++ b/src/_data/team/ben-hardill.json
@@ -1,4 +1,5 @@
 {
+    "order": 3,
     "name": "Ben Hardill",
     "title": "Senior Software Developer",
     "twitter": "hardillb",

--- a/src/_data/team/ian-skerrett.json
+++ b/src/_data/team/ian-skerrett.json
@@ -1,4 +1,5 @@
 {
+    "order": 9,
     "name": "Ian Skerrett",
     "title": "Head of Marketing",
     "twitter": "iskerrett",

--- a/src/_data/team/joe-pavitt.json
+++ b/src/_data/team/joe-pavitt.json
@@ -1,4 +1,5 @@
 {
+    "order": 5,
     "name": "Joe Pavitt",
     "title": "Head of UX & Design",
     "twitter": "joepavitt3d",

--- a/src/_data/team/marian-demme.json
+++ b/src/_data/team/marian-demme.json
@@ -1,4 +1,5 @@
 {
+    "order": 10,
     "name": "Marian Demme",
     "title": "Product Manager",
     "twitter": "DemmeMarian",

--- a/src/_data/team/nick-oleary.json
+++ b/src/_data/team/nick-oleary.json
@@ -1,4 +1,5 @@
 {
+    "order": 2,
     "name": "Nick O'Leary",
     "title": "CTO",
     "twitter": "knolleary",

--- a/src/_data/team/pez-cuckow.json
+++ b/src/_data/team/pez-cuckow.json
@@ -1,4 +1,5 @@
 {
+    "order": 6,
     "name": "Pez Cuckow",
     "title": "Senior Software Developer",
     "twitter": "Pezmc",

--- a/src/_data/team/rob-marcer.json
+++ b/src/_data/team/rob-marcer.json
@@ -1,4 +1,5 @@
 {
+    "order": 7,
     "name": "Rob Marcer",
     "title": "Developer Educator",
     "github": "robmarcer",

--- a/src/_data/team/stephen-mclaughlin.json
+++ b/src/_data/team/stephen-mclaughlin.json
@@ -1,4 +1,5 @@
 {
+    "order": 4,
     "name": "Steve McLaughlin",
     "title": "Node-RED OSS Developer",
     "twitter": "Steve_D_Mcl",

--- a/src/_data/team/tracy-anthony.json
+++ b/src/_data/team/tracy-anthony.json
@@ -1,4 +1,5 @@
 {
+    "order": 8,
     "name": "Tracy Anthony",
     "title": "HR Manager",
     "github": "Tracy-Anthony",

--- a/src/_data/team/yndira-escobar.json
+++ b/src/_data/team/yndira-escobar.json
@@ -1,4 +1,5 @@
 {
+    "order": 11,
     "name": "Yndira Escobar",
     "title": "Visual Designer",
     "github": "Yndira-FlowForge",

--- a/src/_data/team/zeger-jan-van-de-weg.json
+++ b/src/_data/team/zeger-jan-van-de-weg.json
@@ -1,4 +1,5 @@
 {
+    "order": 1,
     "name": "ZJ van de Weg",
     "title": "CEO",
     "twitter": "ZJvandeWeg",

--- a/src/team.njk
+++ b/src/team.njk
@@ -5,7 +5,7 @@ layout: layouts/nohero.njk
 <div class="team w-full pb-48 ff-bg-light">
     <div class="container m-auto text-left max-w-4xl">
         <div class="grid grid-cols-1 gap-8 sm:grid-cols-2 md:grid-cols-3">
-            {%- for name, member in team -%}
+            {%- for member in team | dictsortBy(false, 'order') -%}
             <div class="team-headshot w-full max-w-xs m-auto">
                 {% set imageSrc = ["./images/team/headshot-", member.headshot ] | join %}
                 {% set imageAlt = ["Photo of ", member.name ] | join %}                


### PR DESCRIPTION
## Description

We lost the correct ordering a while back when our `team.json` was removed, falling back to the file order (alphabetical). This re-introduces order based on a new `order` key. Ordering is done by C-Suite, followed by joined date.

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)