### PR TITLE
SOC: Add initial info-sec and acceptable-usage policy

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,5 +7,8 @@
 /src/handbook/marketing @iskerrett
 /src/handbook/product @MarianRaphael
 
+# Security Polices
+/src/handbook/company/security/information-security.md @ZJvandeWeg
+
 # Change in values need sign off from both the CEO and CTO
 /src/handbook/company/values.md @knolleary @ZJvandeWeg

--- a/src/handbook/company/security/index.md
+++ b/src/handbook/company/security/index.md
@@ -4,6 +4,15 @@ navTitle: Security
 
 # Security
 
+To ensure the safety and security of our company, employees and customers, FlowForge
+maintains a set of security policies that we all must follow.
+
+It is important that every takes the time to understand their own responsibilities
+in this area, which includes prompt reporting and resolution of any issues identified.
+
+ - [Information Security Policy and Acceptable Use Policy](./information-security.md)
+
+
 ## Credentials
 
 ### Password vault

--- a/src/handbook/company/security/index.md
+++ b/src/handbook/company/security/index.md
@@ -34,6 +34,6 @@ For all services that support it, 2FA authentication should be enabled and if po
 
 The CEO, CTO, and other executives at FlowForge will never email anyone to wire
 money, request you to buy gift cards, or request any other type of monitory
-transaction. Transactions are started through [a set process](../operations/vendors.md)
+transaction. Transactions are started through [a set process](../../operations/vendors.md)
 only. When in doubt, reach out through Slack and request a call with the executive
 to validate.

--- a/src/handbook/company/security/index.md
+++ b/src/handbook/company/security/index.md
@@ -4,7 +4,7 @@ navTitle: Security
 
 # Security
 
-To ensure the safety and security of our company, employees and customers, FlowForge
+To ensure the safety and security of our company, employees, and customers, FlowForge
 maintains a set of security policies that we all must follow.
 
 It is important that every takes the time to understand their own responsibilities

--- a/src/handbook/company/security/information-security.md
+++ b/src/handbook/company/security/information-security.md
@@ -15,11 +15,7 @@ This Information Security Policy is intended to protect FlowForge’s employees,
 partners and the company from illegal or damaging actions by individuals, either
 knowingly or unknowingly.
 
-Internet-related systems, including but not limited to computer equipment,
-software, operating systems, storage media, network accounts providing electronic
-mail, web browsing, and file transfers, are the property of FlowForge.
-
-These systems are to be used for business purposes in serving the interests of
+FlowForge systems are to be used for business purposes in serving the interests of
 the company, and of our clients and customers in the course of normal operations.
 
 Effective security is a team effort involving the participation and support of
@@ -73,7 +69,8 @@ inappropriate conduct and actions. It is the responsibility of all employees to
 report concerns about violations of our code of ethics or suspected violations
 of law or regulations that govern our operations.
 
-It is contrary to our values for anyone to retaliate against any employee or who
+We value [using candor](./../../company/values.md#use-candor) within the company.
+It is contrary to that value for anyone to retaliate against any employee or who
 in good faith reports an ethics violation, or a suspected violation of law, such
 as a complaint of discrimination, or suspected fraud, or suspected violation of
 any regulation. An employee who retaliates against someone who has reported a
@@ -95,26 +92,26 @@ to secure a device is prohibited.
 3. All end-user, personal (BYOD) or company owned devices used to access FlowForge
 information systems (i.e. email) must adhere to the following rules and requirements:
 
-4. Devices must be secured with a password (or equivalent control such as biometric)
+  1. Devices must be secured with a password (or equivalent control such as biometric)
    protected screensaver or screen lock.
 
-5. Devices must not be left unattended in public.
+  2. Devices must not be left unattended in public.
 
-6. Users must report any suspected misuse or theft of a mobile device immediately
+4. Users must report any suspected misuse or theft of a mobile device immediately
    to security@flowforge.com
 
-7. Avoid sharing credentials. Secrets must be stored safely, using features such
+5. Avoid sharing credentials. Secrets must be stored safely, using features such
    as GitHub Secrets. For accounts and other sensitive data that need to be shared
-   use the company-provided password manager and ensure an appropriate scope of
-   sharing is used.
+   use the company-provided password manager, 1Password, and ensure an appropriate
+   scope of sharing is used.
 
-9. Confidential information must not be stored on portable media such as USB drives
+6. Confidential information must not be stored on portable media such as USB drives
 
-9. Accessing FlowForge systems on public "shared" computers, such as hotel kiosks
+7. Accessing FlowForge systems on public "shared" computers, such as hotel kiosks
    is strictly prohibited
 
-10. Upon termination users agree to return all company owned devices and delete
-    all company information and accounts from any personal devices 
+8. Upon termination users agree to return all company owned devices and delete
+   all company information and accounts from any personal devices 
 
 ## Acceptable Use Policy
 
@@ -185,7 +182,8 @@ external audits.
 ## Exceptions
 
 Requests for an exception to this policy must be submitted to the CTO or CEO for
-approval.
+approval by raising an issue on the [admin repository](https://github.com/flowforge/admin){rel="nofollow"}
+or via email if confidentiality is required.
 
 ## Violations & Enforcement
 

--- a/src/handbook/company/security/information-security.md
+++ b/src/handbook/company/security/information-security.md
@@ -64,24 +64,6 @@ details.
 Any security issue related to vulnerabilities in the product should be reported
 via our [disclosure policy](../../development/security.md).
 
-## Whistleblower Reporting
-
-Our Whistleblower Policy is intended to encourage and enable employees and
-others to raise serious concerns internally so that we can address and correct
-inappropriate conduct and actions. It is the responsibility of all employees to
-report concerns about violations of our code of ethics or suspected violations
-of law or regulations that govern our operations.
-
-We value [using candor](./../../company/values.md#use-candor) within the company.
-It is contrary to that value for anyone to retaliate against any employee or who
-in good faith reports an ethics violation, or a suspected violation of law, such
-as a complaint of discrimination, or suspected fraud, or suspected violation of
-any regulation. An employee who retaliates against someone who has reported a
-violation in good faith is subject to discipline up to and including termination
-of employment.
-
-Anonymous reports may be submitted via [LINK TO BE ADDED]().
-
 ## Device Policy
 
 All end-user devices (e.g., mobile phones, tablets, laptops, desktops) must

--- a/src/handbook/company/security/information-security.md
+++ b/src/handbook/company/security/information-security.md
@@ -61,6 +61,9 @@ reported immediately or as soon as possible by sending an email to security@flow
 In your email please describe the incident or observation along with any relevant
 details.
 
+Any security issue related to vulnerabilities in the product should be reported
+via our [disclosure policy](../../development/security.md).
+
 ## Whistleblower Reporting
 
 Our Whistleblower Policy is intended to encourage and enable employees and

--- a/src/handbook/company/security/information-security.md
+++ b/src/handbook/company/security/information-security.md
@@ -1,0 +1,195 @@
+---
+navTitle: Information Security Policy and Acceptable Use Policy
+---
+
+# Information Security Policy and Acceptable Use Policy
+
+| Policy owner   | Effective date |
+| -------------- | -------------- |
+| @ZJvandeWeg    | 2023-05-01     |
+
+
+## Overview
+
+This Information Security Policy is intended to protect FlowForge’s employees,
+partners and the company from illegal or damaging actions by individuals, either
+knowingly or unknowingly.
+
+Internet-related systems, including but not limited to computer equipment,
+software, operating systems, storage media, network accounts providing electronic
+mail, web browsing, and file transfers, are the property of FlowForge.
+
+These systems are to be used for business purposes in serving the interests of
+the company, and of our clients and customers in the course of normal operations.
+
+Effective security is a team effort involving the participation and support of
+every FlowForge employee or contractor who deals with information and/or
+information systems. It is the responsibility of every team member to read and
+understand this policy, and to conduct their activities accordingly.
+
+## Purpose 
+
+The purpose of this policy is to communicate our information security policies
+and outline the acceptable use and protection of FlowForge’s information and
+assets. These rules are in place to protect customers, employees, and FlowForge.
+Inappropriate use exposes FlowForge to risks including virus attacks, compromise
+of network systems and services, financial and reputational risk, and legal and
+compliance issues.
+
+The FlowForge "Information Security Policy" is comprised of this policy and all
+FlowForge policies referenced and/or linked within this document.
+
+## Scope
+
+This policy applies to the use of information, electronic and computing devices,
+and network resources to conduct FlowForge business or interact with internal
+networks and business systems, whether owned or leased by FlowForge, the employee,
+or a third party. All employees, contractors, consultants, temporary, and other
+workers at FlowForge and its subsidiaries are responsible for exercising good
+judgment regarding appropriate use of information, electronic devices, and
+network resources in accordance with FlowForge policies and standards, and local
+laws and regulations.
+
+This policy applies to employees, contractors, consultants, temporaries, and
+other workers at FlowForge, including all personnel affiliated with third
+parties. This policy applies to all FlowForge-controlled company and customer
+data as well as all equipment, systems, networks and software owned or leased by
+FlowForge.
+
+## Security Incident Reporting
+
+All users are required to report known or suspected security events or incidents,
+including policy violations and observed security weaknesses. Incidents shall be
+reported immediately or as soon as possible by sending an email to security@flowforge.com.
+
+In your email please describe the incident or observation along with any relevant
+details.
+
+## Whistleblower Reporting
+
+Our Whistleblower Policy is intended to encourage and enable employees and
+others to raise serious concerns internally so that we can address and correct
+inappropriate conduct and actions. It is the responsibility of all employees to
+report concerns about violations of our code of ethics or suspected violations
+of law or regulations that govern our operations.
+
+It is contrary to our values for anyone to retaliate against any employee or who
+in good faith reports an ethics violation, or a suspected violation of law, such
+as a complaint of discrimination, or suspected fraud, or suspected violation of
+any regulation. An employee who retaliates against someone who has reported a
+violation in good faith is subject to discipline up to and including termination
+of employment.
+
+Anonymous reports may be submitted via [LINK TO BE ADDED]().
+
+## Device Policy
+
+All end-user devices (e.g., mobile phones, tablets, laptops, desktops) must
+comply with this policy.
+
+1. System level and user level passwords must comply with the [Access Control Policy]().
+
+2. Providing access to another individual, either deliberately or through failure
+to secure a device is prohibited.
+
+3. All end-user, personal (BYOD) or company owned devices used to access FlowForge
+information systems (i.e. email) must adhere to the following rules and requirements:
+
+4. Devices must be secured with a password (or equivalent control such as biometric)
+   protected screensaver or screen lock.
+
+5. Devices must not be left unattended in public.
+
+6. Users must report any suspected misuse or theft of a mobile device immediately
+   to security@flowforge.com
+
+7. Avoid sharing credentials. Secrets must be stored safely, using features such
+   as GitHub Secrets. For accounts and other sensitive data that need to be shared
+   use the company-provided password manager and ensure an appropriate scope of
+   sharing is used.
+
+9. Confidential information must not be stored on portable media such as USB drives
+
+9. Accessing FlowForge systems on public "shared" computers, such as hotel kiosks
+   is strictly prohibited
+
+10. Upon termination users agree to return all company owned devices and delete
+    all company information and accounts from any personal devices 
+
+## Acceptable Use Policy
+
+FlowForge proprietary and customer information stored on electronic and computing
+devices, whether owned or leased by FlowForge, the employee or a third party,
+remains the sole property of FlowForge for the purposes of this policy.
+
+Employees and contractors must ensure through legal or technical means that
+proprietary information is protected in accordance with the [Data Management Policy]().
+
+Google Drive should be used to store and share files within the company, ensuring
+proper access controls are applied.
+
+You have a responsibility to promptly report the theft, loss, or unauthorized
+disclosure of FlowForge proprietary information or equipment. You may access,
+use or share FlowForge proprietary information only to the extent it is authorized
+and necessary to fulfill your assigned job duties.
+
+Employees are responsible for exercising good judgment regarding the
+reasonableness of personal use of company-provided devices.
+
+For security and network maintenance purposes, authorized individuals within
+FlowForge may monitor equipment, systems and network traffic at any time.
+FlowForge reserves the right to audit networks and systems on a periodic basis
+to ensure compliance with this policy.
+
+Employees must ensure the software they use is properly licensed and used as
+intended.
+
+## Unacceptable Use
+
+Under no circumstances is an employee of FlowForge authorized to engage in any
+activity that is illegal under local, state, federal or international law while
+utilizing FlowForge-owned resources or while representing FlowForge in any capacity.
+
+## Additional Policies and Procedures Incorporated by Reference
+
+Personnel are responsible for reading and complying with all policies relevant
+to their roles and responsibilities.
+
+The following table lists the policies that form our Information Security model.
+
+This table will be updated with links to the individual policy documents as they
+get added to the handbook and adopted.
+
+Role | Purpose
+---|---
+Access Control Policy | To limit access to information and information processing systems, networks, and facilities to authorized parties in accordance with business objectives.
+Asset Management Policy | To identify organizational assets and define appropriate protection responsibilities. 
+Business Continuity & Disaster Recovery Plan | To prepare FlowForge in the event of extended service outages caused by factors beyond our control (e.g., natural disasters, man-made events), and to restore services to the widest extent possible in a minimum time frame.
+Cryptography Policy | To ensure proper and effective use of cryptography to protect the confidentiality, authenticity and/or integrity of information.
+Data Management Policy | To ensure that information is classified and protected in accordance with its importance to the organization.
+Human Resources Policy | To ensure that employees and contractors meet security requirements, understand their responsibilities, and are suitable for their roles.
+Incident Response Plan | Policy and procedures for suspected or confirmed information security incidents.
+Operations Security Policy | To ensure the correct and secure operation of information processing systems and facilities.
+Physical Security Policy | To prevent unauthorized physical access or damage to the organization’s information and information processing facilities.
+Risk Management Policy | To define the process for assessing and managing FlowForge's information security risks in order to achieve the company’s business and information security objectives.
+Secure Development Policy | To ensure that information security is designed and implemented within the development lifecycle for applications and information systems.
+Third-Party Management Policy | To ensure protection of the organization's data and assets that are shared with, accessible to, or managed by suppliers, including external parties or third-party organizations such as service providers, vendors, and customers, and to maintain an agreed level of information security and service delivery in line with supplier agreements.
+
+
+## Policy Compliance
+
+FlowForge will measure and verify compliance to this policy through various
+methods, including but not limited to ongoing monitoring, and both internal and
+external audits.
+
+## Exceptions
+
+Requests for an exception to this policy must be submitted to the CTO or CEO for
+approval.
+
+## Violations & Enforcement
+
+Any known violations of this policy should be reported to the CTO or CEO.
+Violations of this policy can result in immediate withdrawal or suspension of
+system and network privileges and/or disciplinary action in accordance with
+company procedures up to and including termination of employment.


### PR DESCRIPTION
Part of https://github.com/flowforge/admin/issues/165

## Description

Adds an initial Information Security Policy document. This is the starting point of our security policy documentation. There are many more to come - see linked issue above for the list.

The content is largely based on the template document provided by Vanta. I have made a few modifications given our all-remote nature.

The info-sec policy in this PR includes some links that need to be updated once other policy docs have been created - but wanted to start getting eyes on the specific details of the policy.

**Please review the content, but do not merge yet**