### PR TITLE
Add explicit declaration for Algolia Netlify plugin to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
         "@11ty/eleventy-img": "^3.0.0",
         "@11ty/eleventy-plugin-rss": "^1.2.0",
         "@11ty/eleventy-plugin-syntaxhighlight": "^4.2.0",
+        "@algolia/netlify-plugin-crawler": "^1.0.15",
         "@flowforge/forge-ui-components": "^0.2.2",
         "@kevingimbel/eleventy-plugin-mermaid": "^2.0.0",
         "@tailwindcss/typography": "^0.4.1",


### PR DESCRIPTION
## Description

Adds the explicit declaration of the dependency to our development dependencies, which fixes the issues raised for Windows users when running `npm start`.

Worked out via these docs: https://docs.netlify.com/integrations/build-plugins/#add-dependency

Odd wasn't required for Mac, but this seems to do the trick.

## Related Issue(s)

Fixes #661

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes