### PR TITLE
Speed up dev mode image handling of website

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -446,23 +446,20 @@ module.exports = function(eleventyConfig) {
         const imgSrc = token.attrGet('src')
         const imgAlt = token.content
         const imgTitle = token.attrGet('title')
+
+        const folderPath = env.page.inputPath
         
-        const parsedTitle = (imgTitle || '').match(
-            /^(?<skip>@skip ?)?(?<title>.*)/
-        ).groups
-
-        if (parsedTitle.skip || imgSrc.startsWith('http')) {
-            const options = { ...htmlOpts }
-            const metadata = { img: [{ url: imgSrc }] }
-            return eleventyImage.generateHTML(metadata, options)
-        }
-
         const widths = [650] // width of blog prose
         const htmlSizes = null
 
         const async = false // cannot run async inside markdown
 
-        return imageHandler(imgSrc, imgAlt, parsedTitle.title, widths, htmlSizes, folderPath, eleventyConfig, async, DEV_MODE)
+        try {
+            return imageHandler(imgSrc, imgAlt, imgTitle, widths, htmlSizes, folderPath, eleventyConfig, async, DEV_MODE)
+        } catch (error) {
+            console.error(`Image generation error while handling: ${imgSrc} in ${folderPath} - ${error}, consider using @skip`)
+            throw error
+        }
     }
 
     eleventyConfig.setLibrary("md", markdownLib)

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -18,6 +18,7 @@ const { minify } = require("terser");
 const codeowners = require('codeowners');
 
 const heroGen = require("./lib/post-hero-gen.js");
+const imageHandler = require('./lib/image-handler.js')
 const site = require("./src/_data/site");
 
 const DEV_MODE = process.env.ELEVENTY_RUN_MODE !== "build" // i.e. serve/watch
@@ -291,65 +292,14 @@ module.exports = function(eleventyConfig) {
         }
     });
 
-    // Custom Shortcodes
-    function resolvedImagePath(inputPath, relativeFilePath) {
-        // Skip URLs
-        try {
-            new URL(string);
-            return relativeFilePath
-        } catch {}
-
-        // Handle both relative to current file and relative root
-        try {
-            const resolvedRelativePath = path.resolve(path.dirname(inputPath), relativeFilePath)
-            if (fs.existsSync(resolvedRelativePath)) {
-                return resolvedRelativePath
-            }
-
-            const resolvedAbsolutePath = path.resolve(eleventyConfig.dir.input, relativeFilePath)
-            if(fs.existsSync(resolvedAbsolutePath)) {
-                return resolvedAbsolutePath
-            }
-        } catch {}
-
-        return relativeFilePath
-    }
-
     // Eleventy Image shortcode
     // https://www.11ty.dev/docs/plugins/image/
     console.info(`[11ty] Image pipeline is enabled in ${DEV_MODE ? 'dev mode' : 'prod mode'} expect a wait for first build`)
     eleventyConfig.addAsyncShortcode("image", async function imageShortcode(src, alt, widths, sizes) {
-        // Full list of formats here: https://www.11ty.dev/docs/plugins/image/#output-formats
-        // Warning: Avif can be resource-intensive so take care!
-        let formats = ["avif", "webp", "auto"];
+        const title = null
+        const currentWorkingFilePath = this.page.inputPath
 
-        // Skip slow formats for local development
-        if (DEV_MODE) {
-            formats = formats.filter((format) => !['avif', 'webp'].includes(format))
-        }
-
-        let file = resolvedImagePath(this.page.inputPath, src);
-        let metadata = await eleventyImage(file, {
-            widths: widths ? widths.concat(widths.map((w) => w * 2)) : ["auto"],
-            formats,
-            outputDir: path.join(eleventyConfig.dir.output, "img"), // Advanced usage note: `eleventyConfig.dir` works here because we’re using addPlugin.
-            filenameFormat: function (hash, src, width, format, options) {
-                const { name } = path.parse(src);
-                return `${name}-${hash}-${width}.${format}`;
-            },
-            svgShortCircuit: true,
-        });
-
-        sizes = sizes || widths ? widths.map((width) => `(min-device-pixel-ratio: 1.25) ${width * 2}px, (min-resolution: 120dpi) ${width * 2}px, ${width}px`).join(', ') : null
-
-        let imageAttributes = {
-            alt,
-            sizes,
-            loading: "lazy",
-            decoding: "async",
-        };
-
-        return eleventyImage.generateHTML(metadata, imageAttributes);
+        return await imageHandler(src, alt, title, widths, sizes, currentWorkingFilePath, eleventyConfig, DEV_MODE)
     });
 
     // Create a collection for sidebar navigation
@@ -492,20 +442,14 @@ module.exports = function(eleventyConfig) {
 
     markdownLib.renderer.rules.image = function (tokens, idx, options, env, self) {
         const token = tokens[idx]
+
         const imgSrc = token.attrGet('src')
         const imgAlt = token.content
         const imgTitle = token.attrGet('title')
-
+        
         const parsedTitle = (imgTitle || '').match(
             /^(?<skip>@skip ?)?(?<title>.*)/
         ).groups
-
-        const htmlOpts = {
-            title: parsedTitle.title,
-            alt: imgAlt,
-            loading: 'lazy',
-            decoding: 'async'
-        }
 
         if (parsedTitle.skip || imgSrc.startsWith('http')) {
             const options = { ...htmlOpts }
@@ -513,49 +457,12 @@ module.exports = function(eleventyConfig) {
             return eleventyImage.generateHTML(metadata, options)
         }
 
-        let formats = ['avif', 'webp', 'jpeg']
-        let extraOpts = {}
-        if (imgSrc.includes('.gif')) {
-            formats = ['webp', 'gif']
-            extraOpts = {
-                sharpOptions: {
-                    animated: true
-                },
-            }
-        }
-
-        // Skip slow formats for local development
-        if (DEV_MODE) {
-            formats = formats.filter((format) => !['avif', 'webp'].includes(format))
-        }
-
-        // Handle both relative to post and root
         const widths = [650] // width of blog prose
-        const imgOpts = {
-            widths: widths.concat(widths.map((w) => w * 2)), // generate 2x sizes (retina)
-            formats,
-            outputDir: path.join(eleventyConfig.dir.output, "img"), // Advanced usage note: `eleventyConfig.dir` works here because we’re using addPlugin.
-            filenameFormat: function (hash, src, width, format, options) {
-                const { name } = path.parse(src);
-                return `${name}-${hash}-${width}.${format}`;
-            },
-            svgShortCircuit: true,
-            ...extraOpts
-        }
+        const htmlSizes = null
 
-        const imagePath = resolvedImagePath(env.page.inputPath, imgSrc)
-        eleventyImage(imagePath, imgOpts).catch((error) => {
-            console.error(`Image generation error while handling: ${imgSrc} in ${env.page.inputPath} - ${error}, consider using @skip`)
-            throw error
-        })
-        const metadata = eleventyImage.statsSync(imagePath, imgOpts)
+        const async = false // cannot run async inside markdown
 
-        const generated = eleventyImage.generateHTML(metadata, {
-            sizes: widths.map((width) => `(min-device-pixel-ratio: 1.25) ${width * 2}px, (min-resolution: 120dpi) ${width * 2}px, ${width}px`).join(', '),
-            ...htmlOpts
-        })
-
-        return generated
+        return imageHandler(imgSrc, imgAlt, parsedTitle.title, widths, htmlSizes, folderPath, eleventyConfig, async, DEV_MODE)
     }
 
     eleventyConfig.setLibrary("md", markdownLib)

--- a/lib/image-handler.js
+++ b/lib/image-handler.js
@@ -169,7 +169,14 @@ module.exports = function imageHandler(
     // In sync mode, while image is generating in a separate thread, stats are estimated synchronously
     eleventyImage(imgPath, imgOpts)
 
-    const htmlMetadata = eleventyImage.statsSync(imgPath, imgOpts)
+    let htmlMetadata
+    if (isURL(imgSrc)) {
+        throw new Error(
+            `Currently remote images are not supported as they cannot be loaded synchronously, please copy ${imgPath} to the local file system`
+        )
+    } else {
+        htmlMetadata = eleventyImage.statsSync(imgPath, imgOpts)
+    }
 
     return eleventyImage.generateHTML(htmlMetadata, htmlOpts)
 }

--- a/lib/image-handler.js
+++ b/lib/image-handler.js
@@ -1,0 +1,175 @@
+const path = require("path")
+const fs = require("fs")
+
+const eleventyImage = require("@11ty/eleventy-img")
+
+/**
+ * Is a particular string a URL
+ * @param {string} url
+ * @returns boolean
+ */
+function isURL(url) {
+    try {
+        new URL(url)
+        return true
+    } catch {
+        return false
+    }
+}
+
+/**
+ * Resolve a file path relative to the input path or eleventy root
+ * @param {string} filePath File to try and find
+ * @param {string} workingFilePath File that is currently being parsed
+ * @param {string} inputFolderPath Input folder directory
+ * @returns
+ */
+function resolvedImagePath(filePath, workingFilePath, inputFolderPath) {
+    // Skip URLs
+    if (isURL(filePath)) {
+        return filePath
+    }
+
+    // Handle both relative to current file and relative to input folder
+    try {
+        const resolvedRelativePath = path.resolve(path.dirname(workingFilePath), filePath)
+        if (fs.existsSync(resolvedRelativePath)) {
+            return resolvedRelativePath
+        }
+
+        const resolvedAbsolutePath = path.resolve(inputFolderPath, filePath)
+        if (fs.existsSync(resolvedAbsolutePath)) {
+            return resolvedAbsolutePath
+        }
+    } catch {}
+
+    return filePath
+}
+
+/**
+ * Converts an image into multiple formats and returns a Picture tag containing those formats]
+ * Automatically:
+ *  - Generates retina and non-retina size images for use on supported screens
+ *  - Converts files to avif and webp
+ *  - Converts gifs to webp
+ * @param {string} imgSrc Relative path (from folder or input directory) to
+ * @param {string} imgAlt Required alt tag describing the image
+ * @param {string} imgTitle Title of the image tag
+ * @param {array<integer>} widths Array of widths (in px) to resize image to
+ * @param {array<string>} sizes Picture tag sizes
+ * @param {string} currentFilePath Will search for image relative to this path
+ * @param {boolean} async Set false to ryn synchronously
+ * @returns {string} HTML Tag
+ */
+module.exports = function imageHandler(
+    imgSrc,
+    imgAlt,
+    imgTitle = null,
+    widths = ["auto"],
+    sizes = null,
+    currentFilePath = null,
+    eleventyConfig = null,
+    async = true,
+    DEV_MODE = false
+) {
+    const eleventyInputFolderPath = eleventyConfig.dir.input
+    const eleventyOutputFolderPath = eleventyConfig.dir.output
+
+    // Image formats to generate
+    // Full list of formats here: https://www.11ty.dev/docs/plugins/image/#output-formats
+    // Warning: Avif can be resource-intensive so take care!
+    let formats = ["avif", "webp", "auto"]
+    let extraOpts = {}
+    if (imgSrc.includes(".gif")) {
+        formats = ["webp", "gif"]
+        extraOpts = {
+            sharpOptions: {
+                animated: true,
+            },
+        }
+    }
+    const parsedTitle = (imgTitle || '').match(
+        /^(?<skip>@skip ?)?(?<title>.*)/
+    ).groups
+
+    const htmlOpts = {
+        title: parsedTitle.title,
+        alt: imgAlt,
+        loading: 'lazy',
+        decoding: 'async'
+    }
+
+    if (parsedTitle.skip || imgSrc.startsWith('http')) {
+        const options = { ...htmlOpts }
+        const metadata = { img: [{ url: imgSrc }] }
+        return eleventyImage.generateHTML(metadata, options)
+    }
+
+    let formats = ['avif', 'webp', 'jpeg']
+    let extraOpts = {}
+    if (imgSrc.includes('.gif')) {
+        formats = ['webp', 'gif']
+        extraOpts = {
+            sharpOptions: {
+                animated: true
+            },
+        }
+    }
+
+    // Skip slow formats for local development
+    if (DEV_MODE) {
+        formats = formats.filter((format) => !['avif', 'webp'].includes(format))
+    }
+
+    // Skip slow formats for local development
+    if (DEV_MODE) {
+        formats = formats.filter((format) => !['avif', 'webp'].includes(format))
+    }
+
+    // Generate retina images
+    const imgWidths = widths.concat(widths.map((w) => (isNaN(w) ? w : w * 2))) // generate 2x sizes (retina)
+    const htmlSizes =
+        sizes ||
+        widths
+            .filter((w) => !isNaN(w))
+            .map(
+                (width) =>
+                    `(min-device-pixel-ratio: 1.25) ${width * 2}px, (min-resolution: 120dpi) ${width * 2}px, ${width}px`
+            )
+
+    // Convert image and grab metadata
+    const imgPath = resolvedImagePath(imgSrc, currentFilePath, eleventyInputFolderPath)
+    const imgOpts = {
+        widths: imgWidths, 
+        formats,
+        outputDir: path.join(eleventyOutputFolderPath, "img"),
+        filenameFormat: function (hash, src, width, format, options) {
+            const { name } = path.parse(src)
+            return `${name}-${hash}-${width}.${format}`
+        },
+        svgShortCircuit: true,
+        ...extraOpts,
+    }
+
+    const htmlOpts = {
+        ...(imgTitle && { title: imgTitle }), // skip if null
+        alt: imgAlt,
+        sizes: htmlSizes.join(", "),
+        loading: "lazy",
+        decoding: "async",
+    }
+
+    // In async mode, image is generated, then stats are read and used to generate HTML
+    if (async) {
+        return eleventyImage(imgPath, imgOpts).then((htmlMetadata) => {
+            return eleventyImage.generateHTML(htmlMetadata, htmlOpts)
+        })
+    }
+
+    // In sync mode, while image is generating in a separate thread, stats are estimated synchronously
+    eleventyImage(imgPath, imgOpts)
+
+    const htmlMetadata = eleventyImage.statsSync(imgPath, imgOpts)
+
+    return eleventyImage.generateHTML(htmlMetadata, htmlOpts)
+}

--- a/lib/image-handler.js
+++ b/lib/image-handler.js
@@ -78,7 +78,7 @@ module.exports = function imageHandler(
     // Image formats to generate
     // Full list of formats here: https://www.11ty.dev/docs/plugins/image/#output-formats
     // Warning: Avif can be resource-intensive so take care!
-    let formats = ["avif", "webp", "auto"]
+    let formats = ["avif", "webp", "jpeg"]
     let extraOpts = {}
     if (imgSrc.includes(".gif")) {
         formats = ["webp", "gif"]
@@ -88,39 +88,7 @@ module.exports = function imageHandler(
             },
         }
     }
-    const parsedTitle = (imgTitle || '').match(
-        /^(?<skip>@skip ?)?(?<title>.*)/
-    ).groups
-
-    const htmlOpts = {
-        title: parsedTitle.title,
-        alt: imgAlt,
-        loading: 'lazy',
-        decoding: 'async'
-    }
-
-    if (parsedTitle.skip || imgSrc.startsWith('http')) {
-        const options = { ...htmlOpts }
-        const metadata = { img: [{ url: imgSrc }] }
-        return eleventyImage.generateHTML(metadata, options)
-    }
-
-    let formats = ['avif', 'webp', 'jpeg']
-    let extraOpts = {}
-    if (imgSrc.includes('.gif')) {
-        formats = ['webp', 'gif']
-        extraOpts = {
-            sharpOptions: {
-                animated: true
-            },
-        }
-    }
-
-    // Skip slow formats for local development
-    if (DEV_MODE) {
-        formats = formats.filter((format) => !['avif', 'webp'].includes(format))
-    }
-
+    
     // Skip slow formats for local development
     if (DEV_MODE) {
         formats = formats.filter((format) => !['avif', 'webp'].includes(format))
@@ -151,12 +119,23 @@ module.exports = function imageHandler(
         ...extraOpts,
     }
 
+    // Skip image parsing if flag is set (@skip in title)
+    const parsedTitle = (imgTitle || '').match(
+        /^(?<skip>@skip ?)?(?<title>.*)/
+    ).groups
+
     const htmlOpts = {
-        ...(imgTitle && { title: imgTitle }), // skip if null
+        ...(parsedTitle.title && { title: parsedTitle.title }), // skip if null
         alt: imgAlt,
         sizes: htmlSizes.join(", "),
         loading: "lazy",
         decoding: "async",
+    }
+
+    if (parsedTitle.skip || imgSrc.startsWith('http')) {
+        const options = { ...htmlOpts }
+        const metadata = { img: [{ url: imgSrc }] }
+        return eleventyImage.generateHTML(metadata, options)
     }
 
     // In async mode, image is generated, then stats are read and used to generate HTML

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,6 +2,7 @@
 port = 8080
 framework = "#static"
 command = "npx @11ty/eleventy --quiet --watch"
+autoLaunch = false
 
 [build]
 command = "npm run build"

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,6 @@
 port = 8080
 framework = "#static"
 command = "npx @11ty/eleventy --quiet --watch"
-autoLaunch = false
 
 [build]
 command = "npm run build"


### PR DESCRIPTION
## Description

- Reduces cold build time (on my machine) from ~60 seconds to ~50 seconds
- Reduces all follow up builds (on my machine) from ~13 seconds to ~4.5 seconds
- Disables Netlify auto-opening web browser on first build, leading to confusing 404
    -  **Of Note:** This means developers will now need to click on the link (or open the browser) manually
- Disables clearing of caching on rebuild
    -  **Of Note:** This means that on first load, developer might be seeing the old page, manual refresh will be needed

### Possible Follow Ups

- Disable image pipeline entirely locally (speeds up first cold build) - downside possible differences between dev and prod

## Related Issue(s)

https://github.com/flowforge/website/issues/632

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [na] Suitable unit/system level tests have been added and they pass
 - [na] Documentation has been updated
