### PR TITLE
add w- class to the footer logo

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -163,7 +163,9 @@
         <div class="py-2 pb-8 px-10 text-white md:py-8 md:max-w-screen-xl xl:mx-auto lg:mx-24">
             <div class="ff-footer-columns md:flex-row justify-center md:space-x-8">
                 <div class="">
-                    {% image "./images/flowforge-logo-wordmark-white.svg", "FlowForge Logo in White", [150] %}
+                    <div class="w-52">
+                        {% image "./images/flowforge-logo-wordmark-white.svg", "FlowForge Logo in White", [150] %}
+                    </div>
                     <div class="copyright-statement">
                         <div>Copyright 2023 FlowForge Inc.</div>
                         <div>All Rights Reserved</div>


### PR DESCRIPTION
## Description

Adds a `w-` class to the logo in the footer, no idea why this happened recently - can only think the image pipeline tripped this by resizing the `png`

## Related Issue(s)

Fixes #702 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes