### PR TITLE
Enable non-FF Employees to appear as Blog Authors

### DIFF
--- a/src/_data/eleventyComputed.js
+++ b/src/_data/eleventyComputed.js
@@ -8,5 +8,8 @@ module.exports = {
                 return title
             }
         }
+    },
+    people: (data) => {
+        return {...data.team, ...data.guests}
     }
 }

--- a/src/_data/guests/andrew-lynch.json
+++ b/src/_data/guests/andrew-lynch.json
@@ -1,4 +1,4 @@
 {
     "name": "Andrew Lynch",
-    "title": "Placeholder Job Title"
+    "title": "Industry Expert"
 }

--- a/src/_data/guests/andrew-lynch.json
+++ b/src/_data/guests/andrew-lynch.json
@@ -1,0 +1,4 @@
+{
+    "name": "Andrew Lynch",
+    "title": "Placeholder Job Title"
+}

--- a/src/_includes/layouts/post.njk
+++ b/src/_includes/layouts/post.njk
@@ -42,9 +42,9 @@ layout: layouts/base.njk
                 <div class="sticky top-4 mt-6 flex flex-col">
                     <h3 class="mb-3">Written By:</h3>
                     {% for author in authors %}
-		      {% if team[author] %}
-		        {% renderTeamMember team[author] %}
-		      {% endif %}
+                        {% if people[author] %}
+                            {% renderTeamMember people[author] %}
+                        {% endif %}
                     {% endfor %}
                     <p>Published on: <time value="{{ item.date }}">{{ date  | shortDate }}</time></p>
                     <h3 class="mb-3 pt-6 border-t-2">Recommended Articles:</h3>


### PR DESCRIPTION
## Description

- New Folder: `/guests/` with a sample `.json` included that follows the structure of the `/team` data
- New global computed property `people` which combines `guests` and `team` for availability across the website
- Changes the `post.njk` to reference `people` instead of `team` in order to include guests.
- Authors will show with no image (plain circle) if no image is provided.

## Related Issue(s)

Closes #674 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
