### PR TITLE
reduce blog image widths & add ff-prose to blog post

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -475,7 +475,7 @@ module.exports = function(eleventyConfig) {
 
         const folderPath = env.page.inputPath
         
-        const widths = [450] // width of blog prose
+        const widths = [650] // maximum width an image can be displayed at as part of blog prose
         const htmlSizes = null
 
         const async = false // cannot run async inside markdown

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -475,7 +475,7 @@ module.exports = function(eleventyConfig) {
 
         const folderPath = env.page.inputPath
         
-        const widths = [650] // width of blog prose
+        const widths = [450] // width of blog prose
         const htmlSizes = null
 
         const async = false // cannot run async inside markdown

--- a/src/_includes/layouts/post.njk
+++ b/src/_includes/layouts/post.njk
@@ -16,7 +16,7 @@ layout: layouts/base.njk
     {% endif %}
     <div class="blog nohero w-full pt-6 pb-24 ff-bg-light">
         <div class="container flex flex-col md:flex-row m-auto text-left px-6 md:max-w-screen-lg gap-8 items-stretch">
-            <div>
+            <div class="ff-prose">
                 <a class="inline-flex align-center gap-1 mb-4" href="/blog">
                     {% include "components/icons/chevron-left.svg" %}
                     Back to Blog Posts

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -61,10 +61,6 @@ h1, h2, h3, h4, h5, p {
     color: theme(colors.teal.300);
 }
 
-picture img {
-    width: 100%;
-}
-
 .container {
     position: relative;
     z-index: 2;

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -62,7 +62,8 @@ h1, h2, h3, h4, h5, p {
 }
 
 picture img {
-width: 100%;}
+    width: 100%;
+}
 
 .container {
     position: relative;


### PR DESCRIPTION
## Description

- Add `ff-prose` class to get FlowForge prose styling on the blog
- Try reducing img widths in blogs to prevent low resolutions images scaling undesirably.
- Remove the forcing of `img` to fill `picture` if it's isn't big enough (causes pixel inflation)

## Related Issue(s)

Issue first noticed in https://github.com/flowforge/website/issues/721

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
