### PR TITLE
Upgrade Netlify cli version & re-enable edge functions

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -13,3 +13,7 @@ package = "@algolia/netlify-plugin-crawler"
   [plugins.inputs]
   branches = ['main', 'live']
   template = "hierarchical"
+  
+[[edge_functions]]
+function = "eleventy-edge"
+path = "/*"

--- a/netlify/edge-functions/eleventy-edge.js
+++ b/netlify/edge-functions/eleventy-edge.js
@@ -3,17 +3,6 @@ import {
     precompiledAppData,
 } from "./_generated/eleventy-edge-app.js";
 
-import { configAsync } from 'https://deno.land/x/dotenv/mod.ts';
-
-try {
-    // when running locally, we need to call this
-    // it'll eerror in Netlify prod, but that's okay
-    await configAsync({export: true});
-} catch (err) {
-    // ignore the error on netlify Prod
-}
-
-// const POSTHOG_APIKEY = 'phc_yVWfmiJ3eiVd2iuLYJIQROuHUN65z3hkhkGvAjjaTL7'; //Deno.env.get("POSTHOG_APIKEY");
 const POSTHOG_APIKEY = Deno.env.get("POSTHOG_APIKEY");
 
 function generateUUID() {
@@ -150,8 +139,8 @@ export default async (request, context) => {
             })
 
             /*
-          A/B Testing
-          */
+                A/B Testing
+            */
             // TODO: Using this means we get two event ids every time we see a new Person
 
             eleventyConfig.addPairedAsyncShortcode("abtesting", async function (content, flag, value) {
@@ -167,7 +156,7 @@ export default async (request, context) => {
                         flags = getExistingFeatureFlags(context)
                     }
                     // set cookies to pass data to client PostHog for bootstrapping
-                    if (flags[flag] && flags[flag] === value) {
+                    if (flags && flags[flag] && flags[flag] === value) {
                         if (requireFlagsRefresh) {
                             const strFlag = encodeURIComponent(JSON.stringify(flags))
                             setCookie(context, "ff-feats", strFlag, 1);

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
         "markdown-it-anchor": "^8.6.7",
         "markdown-it-footnote": "^3.0.3",
         "mocha": "^10.2.0",
-        "netlify-cli": "^13.2.1",
+        "netlify-cli": "^15.0.2",
         "nodemon": "^2.0.20",
         "npm-run-all": "^4.1.5",
         "postcss": "^8.3.11",


### PR DESCRIPTION
## Description

Our support request with Netlify has been updated to suggest that Netlify should now support the edge functions without error'ing. 

This should be fixed in to parts:

1. Fix on Netlify side which means we no longer need the `try/catch`
2. Upgrade Netlify client to v14+ (now set to 15 in our `package.json`)


## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes