### PR TITLE
A/B Testing - Banner Color

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -499,15 +499,13 @@ module.exports = function(eleventyConfig) {
                     collapseWhitespace: true,
                     conservativeCollapse: true,
                     preserveLineBreaks: true,
-                    removeComments: true,
+                    removeComments: false,
                     removeEmptyAttributes: true,
                     removeRedundantAttributes: true,
                     useShortDoctype: true,
                 })
-
                 return minified
             }
-
             return content
         })
     }

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,6 @@ package-lock.json
 .vscode/
 
 # Eleventy Edge Build Data files
-netlify/edge-functions/_generated
+netlify/edge-functions/_generated/
 
 .env

--- a/netlify.toml
+++ b/netlify.toml
@@ -13,3 +13,7 @@ package = "@algolia/netlify-plugin-crawler"
   [plugins.inputs]
   branches = ['main', 'live']
   template = "hierarchical"
+  
+[[edge_functions]]
+function = "eleventy-edge"
+path = "/*"

--- a/netlify/edge-functions/_generated/eleventy-edge-app.js
+++ b/netlify/edge-functions/_generated/eleventy-edge-app.js
@@ -1,9 +1,0 @@
-import { EleventyEdge } from "https://cdn.11ty.dev/edge@2.0.2/eleventy-edge.js";
-
-const precompiledAppData = { "eleventy": { "compatibility": ">=2" },
-"buildTimeData": {},
-"nunjucksPrecompiled": {
-  
-} };
-
-export { EleventyEdge, precompiledAppData }

--- a/netlify/edge-functions/ee.js
+++ b/netlify/edge-functions/ee.js
@@ -1,0 +1,214 @@
+import {
+    EleventyEdge,
+    precompiledAppData,
+} from "./_generated/eleventy-edge-app.js";
+
+const POSTHOG_APIKEY = Deno.env.get("POSTHOG_APIKEY");
+
+function generateUUID() {
+    function genSubString () {
+        return Math.random().toString(36).slice(2)
+    }
+    return `${genSubString()}-${genSubString()}-${genSubString()}`
+}
+
+function getCookie(context, cookie) {
+    return context.cookies.get(cookie);
+}
+
+function setCookie(context, name, value) {
+    context.cookies.set({
+        name,
+        value,
+        path: "/",
+        httpOnly: false,
+        secure: true,
+        sameSite: "Lax",
+    });
+}
+
+function decodeJsonCookie (cookie) {
+    const decoded = decodeURIComponent(cookie)
+    return JSON.parse(decoded);
+}
+
+/*
+  Check if this is a person we already recognise in PostHog (they will have a PostHog cookie)
+  If not, we need to geenrate a random identifier for them
+  */
+function getDistinctId (context) {
+    console.log('get distinct id')
+    console.log(POSTHOG_APIKEY)
+    const phCookie = getCookie(context, `ph_${POSTHOG_APIKEY}_posthog`)
+    const ffDistinctId = getCookie(context, `ff-distinctid`)
+    console.log(phCookie)
+    console.log(ffDistinctId)
+    if (phCookie) {
+        return decodeJsonCookie(phCookie).distinct_id
+    } else if (ffDistinctId) {
+        return ffDistinctId
+    } else {
+        return generateUUID()
+    }
+}
+
+function getExistingFeatureFlags (context) {
+    const phCookie = getCookie(context, `ff-feats`)
+    if (phCookie) {
+        return decodeJsonCookie(phCookie)
+    } else {
+        return null
+    }
+}
+
+/*
+  Are we missing a value for this feat?
+  */
+function isNewFlag (context, flag) {
+    const flags = getExistingFeatureFlags(context)
+    return !flags || !!!(flags[flag])
+}
+
+async function getPHFeatureFlags (distinctId) {
+    return new Promise ((resolve, reject) => {
+        fetch('https://eu.posthog.com/decide?v=2', {
+            method: 'POST',
+            body: JSON.stringify({
+                "api_key": POSTHOG_APIKEY,
+                "distinct_id": distinctId
+            })
+        }).then((response) => {
+            return response.json()
+        }).then((data) => {
+            resolve(data.featureFlags)
+        }).catch((err) => {
+            reject(err)
+        })
+    })
+}
+
+async function featureFlagCalled (distinctId, feature, value) {
+    return new Promise ((resolve, reject) => {
+        fetch('https://eu.posthog.com/capture', {
+            method: 'POST',
+            body: JSON.stringify({
+                "api_key": POSTHOG_APIKEY,
+                "distinct_id": distinctId,
+                "event": "$feature_flag_called",
+                "properties": {
+                    "$feature_flag": feature,
+                    "$feature_flag_response": value
+                }
+            })
+        }).then((response) => {
+            return response.json()
+        }).then((data) => {
+            resolve(data)
+        }).catch((err) => {
+            console.error(err)
+        })
+    })
+}
+
+export default async (request, context) => { 
+    try {
+        console.log('edge function')
+        let edge = new EleventyEdge("edge", {
+            request,
+            context,
+            precompiled: precompiledAppData,
+            // default is [], add more keys to opt-in e.g. ["appearance", "username"]
+            cookies: ['ff-feats', 'ff-distinctid', `ph_${POSTHOG_APIKEY}_posthog`, 'ff-test'],
+        });
+
+
+        function decodeJsonCookie (cookie) {
+            const decoded = decodeURIComponent(cookie)
+            return JSON.parse(decoded)
+        }
+
+        edge.config((eleventyConfig) => {
+
+            console.log('eleventy config')
+
+            // Add some custom Edge-specific configuration
+            // e.g. Fancier json output
+            // eleventyConfig.addFilter("json", obj => JSON.stringify(obj, null, 2));
+
+            eleventyConfig.addFilter("json", (content) => {
+                console.log('json edge filter')
+                return JSON.stringify(content, null, 2)
+            });
+
+            eleventyConfig.addPairedShortcode("shortcodetest", async function (content) {
+                return `${content} - shortcode at edge`
+            })
+
+            eleventyConfig.addGlobalData('distinctId', function () {
+                const distinctId = getDistinctId(context);
+                return distinctId
+            })
+
+            /*
+                A/B Testing
+            */
+            // TODO: Using this means we get two event ids every time we see a new Person
+
+            // eleventyConfig.addPairedAsyncShortcode("abtesting", async function (content, flag, value) {
+            //     console.log('ab testing shortcode')
+            //     try {
+            //         if (POSTHOG_APIKEY) {
+            //             const distinctId = this.ctx.environments.distinctId
+            //             setCookie(context, "ff-distinctid", distinctId, 1);
+            //             const requireFlagsRefresh = isNewFlag(context, flag)
+            //             console.log('is new flag:', requireFlagsRefresh)
+            //             var flags
+            //             if (requireFlagsRefresh) {
+            //                 // call PostHog /decide API - not billed $$$ for this
+            //                 flags = await getPHFeatureFlags(distinctId)
+            //             } else {
+            //                 flags = getExistingFeatureFlags(context)
+            //             }
+            //             console.log('flags')
+            //             console.log(flags)
+            //             // set cookies to pass data to client PostHog for bootstrapping
+            //             if (flags && flags[flag] && flags[flag] === value) {
+            //                 if (requireFlagsRefresh) {
+            //                     const strFlag = encodeURIComponent(JSON.stringify(flags))
+            //                     setCookie(context, "ff-feats", strFlag, 1);
+            //                     // inform PostHog we have used a Feature Flag to track in our experiment - we are $$$ for this
+            //                     await featureFlagCalled(distinctId, flag, value)
+            //                 }
+            //                 return `${content}`
+            //             } else if (!flags[flag] && value === 'control') {
+            //                 // this is not a valid feature flag - fall back to the "control" content
+            //                 console.warn(`WARN: Could not find feature flag: '${flag}'. Falling back to "control" content`)
+            //                 return `${content}`
+            //             } else {
+            //                 return ''
+            //             }
+            //         } else if (value === 'control') {
+            //             console.warn('WARN: No PostHog API Key - Falling back to A/B "control" content across the website')
+            //             // fallback to control if we have no PostHog API key
+            //             return `${content}`
+            //         }
+            //     } catch (err) {
+            //         console.error("ERROR", { err });
+            //     }
+            // })
+
+            console.log('edge.renderManager')
+            console.log(edge.renderManager)
+            console.log(edge.renderManager.templateConfig.userConfig.liquidPairedShortcodes)
+
+            console.log('eleventy config end')
+        });
+        console.log('after eleventy config')
+        const distinctId = getDistinctId(context)
+        setCookie(context, "ff-distinctid", distinctId, 1);
+        return await edge.handleResponse();
+    } catch (e) {
+        console.error("ERROR", { e });
+        return context.next(e);
+    }
+};

--- a/netlify/edge-functions/eleventy-edge.js
+++ b/netlify/edge-functions/eleventy-edge.js
@@ -77,6 +77,8 @@ async function getPHFeatureFlags (distinctId) {
             return response.json()
         }).then((data) => {
             resolve(data.featureFlags)
+        }).catch((err) => {
+            reject(err)
         })
     })
 }
@@ -144,10 +146,12 @@ export default async (request, context) => {
             // TODO: Using this means we get two event ids every time we see a new Person
 
             eleventyConfig.addPairedAsyncShortcode("abtesting", async function (content, flag, value) {
+                console.log('ab testing shortcode')
                 if (POSTHOG_APIKEY) {
                     const distinctId = this.ctx.environments.distinctId
                     setCookie(context, "ff-distinctid", distinctId, 1);
                     const requireFlagsRefresh = isNewFlag(context, flag)
+                    console.log('is new flag:', requireFlagsRefresh)
                     var flags
                     if (requireFlagsRefresh) {
                         // call PostHog /decide API - not billed $$$ for this
@@ -155,6 +159,8 @@ export default async (request, context) => {
                     } else {
                         flags = getExistingFeatureFlags(context)
                     }
+                    console.log('flags')
+                    console.log(flags)
                     // set cookies to pass data to client PostHog for bootstrapping
                     if (flags && flags[flag] && flags[flag] === value) {
                         if (requireFlagsRefresh) {

--- a/netlify/edge-functions/eleventy-edge.js
+++ b/netlify/edge-functions/eleventy-edge.js
@@ -38,6 +38,7 @@ function decodeJsonCookie (cookie) {
   */
 function getDistinctId (context) {
     console.log('get distinct id')
+    console.log(POSTHOG_APIKEY)
     const phCookie = getCookie(context, `ph_${POSTHOG_APIKEY}_posthog`)
     const ffDistinctId = getCookie(context, `ff-distinctid`)
     console.log(phCookie)

--- a/netlify/edge-functions/eleventy-edge.js
+++ b/netlify/edge-functions/eleventy-edge.js
@@ -121,6 +121,8 @@ export default async (request, context) => {
             cookies: ['ff-feats', 'ff-distinctid', `ph_${POSTHOG_APIKEY}_posthog`, 'ff-test'],
         });
 
+        console.log(edge)
+
         function decodeJsonCookie (cookie) {
             const decoded = decodeURIComponent(cookie)
             return JSON.parse(decoded)

--- a/netlify/edge-functions/eleventy-edge.js
+++ b/netlify/edge-functions/eleventy-edge.js
@@ -139,9 +139,9 @@ export default async (request, context) => {
                 return JSON.stringify(content, null, 2)
             });
 
-            eleventyConfig.addPairedShortcode("shortcodetest", async function (content) {
-                return `${content} - shortcode at edge`
-            })
+            // eleventyConfig.addPairedShortcode("shortcodetest", async function (content) {
+            //     return `${content} - shortcode at edge`
+            // })
 
             eleventyConfig.addGlobalData('distinctId', function () {
                 const distinctId = getDistinctId(context);
@@ -153,49 +153,48 @@ export default async (request, context) => {
             */
             // TODO: Using this means we get two event ids every time we see a new Person
 
-            eleventyConfig.addPairedAsyncShortcode("abtesting", async function (content, flag, value) {
-                console.log('ab testing shortcode')
-                try {
-                    if (POSTHOG_APIKEY) {
-                        const distinctId = this.ctx.environments.distinctId
-                        setCookie(context, "ff-distinctid", distinctId, 1);
-                        const requireFlagsRefresh = isNewFlag(context, flag)
-                        console.log('is new flag:', requireFlagsRefresh)
-                        var flags
-                        if (requireFlagsRefresh) {
-                            // call PostHog /decide API - not billed $$$ for this
-                            flags = await getPHFeatureFlags(distinctId)
-                        } else {
-                            flags = getExistingFeatureFlags(context)
-                        }
-                        console.log('flags')
-                        console.log(flags)
-                        // set cookies to pass data to client PostHog for bootstrapping
-                        if (flags && flags[flag] && flags[flag] === value) {
-                            if (requireFlagsRefresh) {
-                                const strFlag = encodeURIComponent(JSON.stringify(flags))
-                                setCookie(context, "ff-feats", strFlag, 1);
-                                // inform PostHog we have used a Feature Flag to track in our experiment - we are $$$ for this
-                                await featureFlagCalled(distinctId, flag, value)
-                            }
-                            return `${content}`
-                        } else if (!flags[flag] && value === 'control') {
-                            // this is not a valid feature flag - fall back to the "control" content
-                            console.warn(`WARN: Could not find feature flag: '${flag}'. Falling back to "control" content`)
-                            return `${content}`
-                        } else {
-                            return ''
-                        }
-                    } else if (value === 'control') {
-                        console.warn('WARN: No PostHog API Key - Falling back to A/B "control" content across the website')
-                        // fallback to control if we have no PostHog API key
-                        return `${content}`
-                    }
-                } catch (err) {
-                    console.error("ERROR", { err });
-                }
-                
-            })
+            // eleventyConfig.addPairedAsyncShortcode("abtesting", async function (content, flag, value) {
+            //     console.log('ab testing shortcode')
+            //     try {
+            //         if (POSTHOG_APIKEY) {
+            //             const distinctId = this.ctx.environments.distinctId
+            //             setCookie(context, "ff-distinctid", distinctId, 1);
+            //             const requireFlagsRefresh = isNewFlag(context, flag)
+            //             console.log('is new flag:', requireFlagsRefresh)
+            //             var flags
+            //             if (requireFlagsRefresh) {
+            //                 // call PostHog /decide API - not billed $$$ for this
+            //                 flags = await getPHFeatureFlags(distinctId)
+            //             } else {
+            //                 flags = getExistingFeatureFlags(context)
+            //             }
+            //             console.log('flags')
+            //             console.log(flags)
+            //             // set cookies to pass data to client PostHog for bootstrapping
+            //             if (flags && flags[flag] && flags[flag] === value) {
+            //                 if (requireFlagsRefresh) {
+            //                     const strFlag = encodeURIComponent(JSON.stringify(flags))
+            //                     setCookie(context, "ff-feats", strFlag, 1);
+            //                     // inform PostHog we have used a Feature Flag to track in our experiment - we are $$$ for this
+            //                     await featureFlagCalled(distinctId, flag, value)
+            //                 }
+            //                 return `${content}`
+            //             } else if (!flags[flag] && value === 'control') {
+            //                 // this is not a valid feature flag - fall back to the "control" content
+            //                 console.warn(`WARN: Could not find feature flag: '${flag}'. Falling back to "control" content`)
+            //                 return `${content}`
+            //             } else {
+            //                 return ''
+            //             }
+            //         } else if (value === 'control') {
+            //             console.warn('WARN: No PostHog API Key - Falling back to A/B "control" content across the website')
+            //             // fallback to control if we have no PostHog API key
+            //             return `${content}`
+            //         }
+            //     } catch (err) {
+            //         console.error("ERROR", { err });
+            //     }
+            // })
 
             console.log('eleventy config end')
         });

--- a/netlify/edge-functions/eleventy-edge.js
+++ b/netlify/edge-functions/eleventy-edge.js
@@ -1,214 +1,35 @@
-import {
-    EleventyEdge,
-    precompiledAppData,
-} from "./_generated/eleventy-edge-app.js";
+import { EleventyEdge, precompiledAppData } from "./_generated/eleventy-edge-app.js";
 
-const POSTHOG_APIKEY = Deno.env.get("POSTHOG_APIKEY");
+export default async (request, context) => {
+  try {
+    let edge = new EleventyEdge("edge", {
+      request,
+      context,
+      precompiled: precompiledAppData,
 
-function generateUUID() {
-    function genSubString () {
-        return Math.random().toString(36).slice(2)
-    }
-    return `${genSubString()}-${genSubString()}-${genSubString()}`
-}
-
-function getCookie(context, cookie) {
-    return context.cookies.get(cookie);
-}
-
-function setCookie(context, name, value) {
-    context.cookies.set({
-        name,
-        value,
-        path: "/",
-        httpOnly: false,
-        secure: true,
-        sameSite: "Lax",
+      // default is [], add more keys to opt-in e.g. ["appearance", "username"]
+      cookies: ["appearance", "username", "repeat"],
     });
-}
 
-function decodeJsonCookie (cookie) {
-    const decoded = decodeURIComponent(cookie)
-    return JSON.parse(decoded);
-}
+    edge.config(eleventyConfig => {
+      // Fancier json output
+      eleventyConfig.addFilter("json", obj => JSON.stringify(obj, null, 2));
+      
+      eleventyConfig.addPairedAsyncShortcode("abtesting", async function (content, input) {
+        console.log('ab testing shortcode')
+        return `Shortcode: ${content} ${input}`
+      })
+    });
 
-/*
-  Check if this is a person we already recognise in PostHog (they will have a PostHog cookie)
-  If not, we need to geenrate a random identifier for them
-  */
-function getDistinctId (context) {
-    console.log('get distinct id')
-    console.log(POSTHOG_APIKEY)
-    const phCookie = getCookie(context, `ph_${POSTHOG_APIKEY}_posthog`)
-    const ffDistinctId = getCookie(context, `ff-distinctid`)
-    console.log(phCookie)
-    console.log(ffDistinctId)
-    if (phCookie) {
-        return decodeJsonCookie(phCookie).distinct_id
-    } else if (ffDistinctId) {
-        return ffDistinctId
-    } else {
-        return generateUUID()
+    return await edge.handleResponse();
+  } catch(e) {
+    // Skip the favicon
+    if(e.message.includes("favicon.ico")) {
+      return context.next(e);
     }
-}
 
-function getExistingFeatureFlags (context) {
-    const phCookie = getCookie(context, `ff-feats`)
-    if (phCookie) {
-        return decodeJsonCookie(phCookie)
-    } else {
-        return null
-    }
-}
-
-/*
-  Are we missing a value for this feat?
-  */
-function isNewFlag (context, flag) {
-    const flags = getExistingFeatureFlags(context)
-    return !flags || !!!(flags[flag])
-}
-
-async function getPHFeatureFlags (distinctId) {
-    return new Promise ((resolve, reject) => {
-        fetch('https://eu.posthog.com/decide?v=2', {
-            method: 'POST',
-            body: JSON.stringify({
-                "api_key": POSTHOG_APIKEY,
-                "distinct_id": distinctId
-            })
-        }).then((response) => {
-            return response.json()
-        }).then((data) => {
-            resolve(data.featureFlags)
-        }).catch((err) => {
-            reject(err)
-        })
-    })
-}
-
-async function featureFlagCalled (distinctId, feature, value) {
-    return new Promise ((resolve, reject) => {
-        fetch('https://eu.posthog.com/capture', {
-            method: 'POST',
-            body: JSON.stringify({
-                "api_key": POSTHOG_APIKEY,
-                "distinct_id": distinctId,
-                "event": "$feature_flag_called",
-                "properties": {
-                    "$feature_flag": feature,
-                    "$feature_flag_response": value
-                }
-            })
-        }).then((response) => {
-            return response.json()
-        }).then((data) => {
-            resolve(data)
-        }).catch((err) => {
-            console.error(err)
-        })
-    })
-}
-
-export default async (request, context) => { 
-    try {
-        console.log('edge function')
-        let edge = new EleventyEdge("edge", {
-            request,
-            context,
-            precompiled: precompiledAppData,
-            // default is [], add more keys to opt-in e.g. ["appearance", "username"]
-            cookies: ['ff-feats', 'ff-distinctid', `ph_${POSTHOG_APIKEY}_posthog`, 'ff-test'],
-        });
-
-
-        function decodeJsonCookie (cookie) {
-            const decoded = decodeURIComponent(cookie)
-            return JSON.parse(decoded)
-        }
-
-        edge.config((eleventyConfig) => {
-
-            console.log('eleventy config')
-
-            // Add some custom Edge-specific configuration
-            // e.g. Fancier json output
-            // eleventyConfig.addFilter("json", obj => JSON.stringify(obj, null, 2));
-
-            eleventyConfig.addFilter("json", (content) => {
-                console.log('json edge filter')
-                return JSON.stringify(content, null, 2)
-            });
-
-            eleventyConfig.addPairedShortcode("shortcodetest", async function (content) {
-                return `${content} - shortcode at edge`
-            })
-
-            eleventyConfig.addGlobalData('distinctId', function () {
-                const distinctId = getDistinctId(context);
-                return distinctId
-            })
-
-            /*
-                A/B Testing
-            */
-            // TODO: Using this means we get two event ids every time we see a new Person
-
-            // eleventyConfig.addPairedAsyncShortcode("abtesting", async function (content, flag, value) {
-            //     console.log('ab testing shortcode')
-            //     try {
-            //         if (POSTHOG_APIKEY) {
-            //             const distinctId = this.ctx.environments.distinctId
-            //             setCookie(context, "ff-distinctid", distinctId, 1);
-            //             const requireFlagsRefresh = isNewFlag(context, flag)
-            //             console.log('is new flag:', requireFlagsRefresh)
-            //             var flags
-            //             if (requireFlagsRefresh) {
-            //                 // call PostHog /decide API - not billed $$$ for this
-            //                 flags = await getPHFeatureFlags(distinctId)
-            //             } else {
-            //                 flags = getExistingFeatureFlags(context)
-            //             }
-            //             console.log('flags')
-            //             console.log(flags)
-            //             // set cookies to pass data to client PostHog for bootstrapping
-            //             if (flags && flags[flag] && flags[flag] === value) {
-            //                 if (requireFlagsRefresh) {
-            //                     const strFlag = encodeURIComponent(JSON.stringify(flags))
-            //                     setCookie(context, "ff-feats", strFlag, 1);
-            //                     // inform PostHog we have used a Feature Flag to track in our experiment - we are $$$ for this
-            //                     await featureFlagCalled(distinctId, flag, value)
-            //                 }
-            //                 return `${content}`
-            //             } else if (!flags[flag] && value === 'control') {
-            //                 // this is not a valid feature flag - fall back to the "control" content
-            //                 console.warn(`WARN: Could not find feature flag: '${flag}'. Falling back to "control" content`)
-            //                 return `${content}`
-            //             } else {
-            //                 return ''
-            //             }
-            //         } else if (value === 'control') {
-            //             console.warn('WARN: No PostHog API Key - Falling back to A/B "control" content across the website')
-            //             // fallback to control if we have no PostHog API key
-            //             return `${content}`
-            //         }
-            //     } catch (err) {
-            //         console.error("ERROR", { err });
-            //     }
-            // })
-
-            console.log('edge.renderManager')
-            console.log(edge.renderManager)
-            console.log(edge.renderManager.templateConfig.userConfig.liquidPairedShortcodes)
-
-            console.log('eleventy config end')
-        });
-        console.log('after eleventy config')
-        const distinctId = getDistinctId(context)
-        setCookie(context, "ff-distinctid", distinctId, 1);
-        return await edge.handleResponse();
-    } catch (e) {
-        console.error("ERROR", { e });
-        return context.next(e);
-    }
+    // TODO Fancy error page
+    console.log( "ERROR", { e } );
+    return context.next(e);
+  }
 };

--- a/netlify/edge-functions/eleventy-edge.js
+++ b/netlify/edge-functions/eleventy-edge.js
@@ -121,7 +121,6 @@ export default async (request, context) => {
             cookies: ['ff-feats', 'ff-distinctid', `ph_${POSTHOG_APIKEY}_posthog`, 'ff-test'],
         });
 
-        console.log(edge)
 
         function decodeJsonCookie (cookie) {
             const decoded = decodeURIComponent(cookie)
@@ -141,9 +140,9 @@ export default async (request, context) => {
                 return JSON.stringify(content, null, 2)
             });
 
-            // eleventyConfig.addPairedShortcode("shortcodetest", async function (content) {
-            //     return `${content} - shortcode at edge`
-            // })
+            eleventyConfig.addPairedShortcode("shortcodetest", async function (content) {
+                return `${content} - shortcode at edge`
+            })
 
             eleventyConfig.addGlobalData('distinctId', function () {
                 const distinctId = getDistinctId(context);
@@ -197,6 +196,10 @@ export default async (request, context) => {
             //         console.error("ERROR", { err });
             //     }
             // })
+
+            console.log('edge.renderManager')
+            console.log(edge.renderManager)
+            console.log(edge.renderManager.templateConfig.userConfig.liquidPairedShortcodes)
 
             console.log('eleventy config end')
         });

--- a/netlify/edge-functions/eleventy-edge.js
+++ b/netlify/edge-functions/eleventy-edge.js
@@ -37,8 +37,11 @@ function decodeJsonCookie (cookie) {
   If not, we need to geenrate a random identifier for them
   */
 function getDistinctId (context) {
+    console.log('get distinct id')
     const phCookie = getCookie(context, `ph_${POSTHOG_APIKEY}_posthog`)
     const ffDistinctId = getCookie(context, `ff-distinctid`)
+    console.log(phCookie)
+    console.log(ffDistinctId)
     if (phCookie) {
         return decodeJsonCookie(phCookie).distinct_id
     } else if (ffDistinctId) {
@@ -131,6 +134,7 @@ export default async (request, context) => {
             // eleventyConfig.addFilter("json", obj => JSON.stringify(obj, null, 2));
 
             eleventyConfig.addFilter("json", (content) => {
+                console.log('json edge filter')
                 return JSON.stringify(content, null, 2)
             });
 
@@ -194,6 +198,7 @@ export default async (request, context) => {
 
             console.log('eleventy config end')
         });
+        console.log('after eleventy config')
         const distinctId = getDistinctId(context)
         setCookie(context, "ff-distinctid", distinctId, 1);
         return await edge.handleResponse();

--- a/netlify/edge-functions/eleventy-edge.js
+++ b/netlify/edge-functions/eleventy-edge.js
@@ -108,6 +108,7 @@ async function featureFlagCalled (distinctId, feature, value) {
 
 export default async (request, context) => { 
     try {
+        console.log('edge function')
         let edge = new EleventyEdge("edge", {
             request,
             context,

--- a/netlify/edge-functions/eleventy-edge.js
+++ b/netlify/edge-functions/eleventy-edge.js
@@ -3,17 +3,6 @@ import {
     precompiledAppData,
 } from "./_generated/eleventy-edge-app.js";
 
-import { configAsync } from 'https://deno.land/x/dotenv/mod.ts';
-
-try {
-    // when running locally, we need to call this
-    // it'll eerror in Netlify prod, but that's okay
-    await configAsync({export: true});
-} catch (err) {
-    // ignore the error on netlify Prod
-}
-
-// const POSTHOG_APIKEY = 'phc_yVWfmiJ3eiVd2iuLYJIQROuHUN65z3hkhkGvAjjaTL7'; //Deno.env.get("POSTHOG_APIKEY");
 const POSTHOG_APIKEY = Deno.env.get("POSTHOG_APIKEY");
 
 function generateUUID() {
@@ -150,8 +139,8 @@ export default async (request, context) => {
             })
 
             /*
-          A/B Testing
-          */
+                A/B Testing
+            */
             // TODO: Using this means we get two event ids every time we see a new Person
 
             eleventyConfig.addPairedAsyncShortcode("abtesting", async function (content, flag, value) {
@@ -167,7 +156,7 @@ export default async (request, context) => {
                         flags = getExistingFeatureFlags(context)
                     }
                     // set cookies to pass data to client PostHog for bootstrapping
-                    if (flags[flag] && flags[flag] === value) {
+                    if (flags && flags[flag] && flags[flag] === value) {
                         if (requireFlagsRefresh) {
                             const strFlag = encodeURIComponent(JSON.stringify(flags))
                             setCookie(context, "ff-feats", strFlag, 1);

--- a/netlify/edge-functions/eleventy-edge.js
+++ b/netlify/edge-functions/eleventy-edge.js
@@ -117,12 +117,16 @@ export default async (request, context) => {
             cookies: ['ff-feats', 'ff-distinctid', `ph_${POSTHOG_APIKEY}_posthog`, 'ff-test'],
         });
 
+        console.log(edge)
+
         function decodeJsonCookie (cookie) {
             const decoded = decodeURIComponent(cookie)
             return JSON.parse(decoded)
         }
 
         edge.config((eleventyConfig) => {
+
+            console.log('eleventy config')
 
             // Add some custom Edge-specific configuration
             // e.g. Fancier json output

--- a/netlify/edge-functions/eleventy-edge.js
+++ b/netlify/edge-functions/eleventy-edge.js
@@ -140,7 +140,7 @@ export default async (request, context) => {
                 return `${content} - shortcode at edge`
             })
 
-            eleventyConfig.addGlobalData('distinctId', async function () {
+            eleventyConfig.addGlobalData('distinctId', function () {
                 const distinctId = getDistinctId(context);
                 return distinctId
             })
@@ -188,6 +188,8 @@ export default async (request, context) => {
                     return `${content}`
                 }
             })
+
+            console.log('eleventy config end')
         });
         const distinctId = getDistinctId(context)
         setCookie(context, "ff-distinctid", distinctId, 1);

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
         "markdown-it-anchor": "^8.6.7",
         "markdown-it-footnote": "^3.0.3",
         "mocha": "^10.2.0",
-        "netlify-cli": "^13.2.1",
+        "netlify-cli": "^15.0.2",
         "nodemon": "^2.0.20",
         "npm-run-all": "^4.1.5",
         "postcss": "^8.3.11",

--- a/src/_includes/components/events-banner.njk
+++ b/src/_includes/components/events-banner.njk
@@ -1,9 +1,9 @@
 {% edge "liquid" %}
-    {% abtesting "event-banner-color" "test" %}
+    {% abtesting "event-banner-color" "control" %}
         <a data-action="event-banner" href="/ask-me-anything/ama-nodered-may/"
             class="hidden md:flex text-center w-full py-1 pb-2 sm:py-4 bg-gray-900 text-white text-sm px-2 gap-1 sm:gap-2 flex-col sm:flex-row items-center justify-center hover:bg-blue-900">
     {% endabtesting "event-banner-color" "control" %}
-    {% abtesting "event-banner-color" "control" %}
+    {% abtesting "event-banner-color" "test" %}
         <a data-action="event-banner" href="/ask-me-anything/ama-nodered-may/"
             class="hidden md:flex text-center w-full py-1 pb-2 sm:py-4 bg-blue-900 text-white text-sm px-2 gap-1 sm:gap-2 flex-col sm:flex-row items-center justify-center hover:bg-gray-900">
     {% endabtesting "event-banner-color" "control" %}

--- a/src/_includes/components/events-banner.njk
+++ b/src/_includes/components/events-banner.njk
@@ -7,7 +7,6 @@
         <a data-action="event-banner" href="/ask-me-anything/ama-nodered-may/"
             class="hidden md:flex text-center w-full py-1 pb-2 sm:py-4 bg-blue-900 text-white text-sm px-2 gap-1 sm:gap-2 flex-col sm:flex-row items-center justify-center hover:bg-gray-900">
     {% endabtesting %}
-    {{ eleventy | json}}
 {% endedge %}
     <span class="hidden sm:block text-teal-300 font-medium">Join our AMA Session</span>
     <span class="hidden sm:block">-</span>

--- a/src/_includes/components/events-banner.njk
+++ b/src/_includes/components/events-banner.njk
@@ -7,6 +7,7 @@
         <a data-action="event-banner" href="/ask-me-anything/ama-nodered-may/"
             class="hidden md:flex text-center w-full py-1 pb-2 sm:py-4 bg-blue-900 text-white text-sm px-2 gap-1 sm:gap-2 flex-col sm:flex-row items-center justify-center hover:bg-gray-900">
     {% endabtesting %}
+    {{ eleventy | json}}
 {% endedge %}
     <span class="hidden sm:block text-teal-300 font-medium">Join our AMA Session</span>
     <span class="hidden sm:block">-</span>

--- a/src/_includes/components/events-banner.njk
+++ b/src/_includes/components/events-banner.njk
@@ -2,11 +2,11 @@
     {% abtesting "event-banner-color" "control" %}
         <a data-action="event-banner" href="/ask-me-anything/ama-nodered-may/"
             class="hidden md:flex text-center w-full py-1 pb-2 sm:py-4 bg-gray-900 text-white text-sm px-2 gap-1 sm:gap-2 flex-col sm:flex-row items-center justify-center hover:bg-blue-900">
-    {% endabtesting "event-banner-color" "control" %}
+    {% endabtesting %}
     {% abtesting "event-banner-color" "test" %}
         <a data-action="event-banner" href="/ask-me-anything/ama-nodered-may/"
             class="hidden md:flex text-center w-full py-1 pb-2 sm:py-4 bg-blue-900 text-white text-sm px-2 gap-1 sm:gap-2 flex-col sm:flex-row items-center justify-center hover:bg-gray-900">
-    {% endabtesting "event-banner-color" "control" %}
+    {% endabtesting %}
 {% endedge %}
     <span class="hidden sm:block text-teal-300 font-medium">Join our AMA Session</span>
     <span class="hidden sm:block">-</span>

--- a/src/_includes/components/events-banner.njk
+++ b/src/_includes/components/events-banner.njk
@@ -1,9 +1,13 @@
-<script>
-
-</script>
-
-<a data-action="event-banner" href="/ask-me-anything/ama-nodered-may/"
-    class="hidden md:flex text-center w-full py-1 pb-2 sm:py-4 bg-gray-900 text-white text-sm px-2 gap-1 sm:gap-2 flex-col sm:flex-row items-center justify-center hover:bg-blue-900">
+{% edge "liquid" %}
+    {% abtesting "event-banner-color" "test" %}
+        <a data-action="event-banner" href="/ask-me-anything/ama-nodered-may/"
+            class="hidden md:flex text-center w-full py-1 pb-2 sm:py-4 bg-gray-900 text-white text-sm px-2 gap-1 sm:gap-2 flex-col sm:flex-row items-center justify-center hover:bg-blue-900">
+    {% endabtesting "event-banner-color" "control" %}
+    {% abtesting "event-banner-color" "control" %}
+        <a data-action="event-banner" href="/ask-me-anything/ama-nodered-may/"
+            class="hidden md:flex text-center w-full py-1 pb-2 sm:py-4 bg-blue-900 text-white text-sm px-2 gap-1 sm:gap-2 flex-col sm:flex-row items-center justify-center hover:bg-gray-900">
+    {% endabtesting "event-banner-color" "control" %}
+{% endedge %}
     <span class="hidden sm:block text-teal-300 font-medium">Join our AMA Session</span>
     <span class="hidden sm:block">-</span>
     <span>

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -91,7 +91,7 @@
     <div class="flex-grow base">
         <div class="w-full">
             <!-- Events Banner -->
-            {% include "../components/events-banner.njk" %}
+            {# {% include "../components/events-banner.njk" %} #}
             <!-- Navigation Header -->
             <header id="ff-header" class="ff-header">
                 <nav class="relative w-full flex items-center justify-between mx-auto container md:max-w-screen-xl">

--- a/src/index.njk
+++ b/src/index.njk
@@ -11,7 +11,7 @@ sitemapPriority: 1.0
         <h3 class="mt-6 text-gray-400 text-lg font-normal">
             FlowForge allows organizations to reliably deliver Node-RED applications in a continuous, collaborative, and secure manner.
             {% edge "liquid" %}
-                {{ eleventy | json}}
+                {{ eleventy | json }}
             {% endedge %}
         </h3>
         <div class="flex flex-col">

--- a/src/index.njk
+++ b/src/index.njk
@@ -10,6 +10,9 @@ sitemapPriority: 1.0
         </h1>
         <h3 class="mt-6 text-gray-400 text-lg font-normal">
             FlowForge allows organizations to reliably deliver Node-RED applications in a continuous, collaborative, and secure manner.
+            {% edge "liquid" %}
+                {{ eleventy | json}}
+            {% endedge %}
         </h3>
         <div class="flex flex-col">
           <div class="m-auto mt-12 flex flex-col gap-4 items-center justify-center">

--- a/src/index.njk
+++ b/src/index.njk
@@ -9,11 +9,11 @@ sitemapPriority: 1.0
             DevOps for Node-RED
         </h1>
         <h3 class="mt-6 text-gray-400 text-lg font-normal">
-            {% edge "liquid" %}
+            {% edge %}
                 Static Content inside Edge Function
             {% endedge %}
             FlowForge allows organizations to reliably deliver Node-RED applications in a continuous, collaborative, and secure manner.
-            {% edge "liquid" %}
+            {% edge %}
                 {{ eleventy | json }}
             {% endedge %}
         </h3>

--- a/src/index.njk
+++ b/src/index.njk
@@ -9,6 +9,9 @@ sitemapPriority: 1.0
             DevOps for Node-RED
         </h1>
         <h3 class="mt-6 text-gray-400 text-lg font-normal">
+            {% edge "liquid" %}
+                Static Content inside Edge Function
+            {% endedge %}
             FlowForge allows organizations to reliably deliver Node-RED applications in a continuous, collaborative, and secure manner.
             {% edge "liquid" %}
                 {{ eleventy | json }}


### PR DESCRIPTION
## Description

- [PostHog Experiment](https://eu.posthog.com/experiments/809)

Due to the low interaction of the event banner:

<img width="947" alt="Screenshot 2023-05-10 at 14 51 43" src="https://github.com/flowforge/website/assets/99246719/a44592e5-86bc-4247-a608-8edca9a30fd6">

This PR adds A/B testing to the banner colour to see if it helps with engagement at all.

## Related Issue(s)

- Will add a link to the A/B Testing Proposal/Issue which will detail the experiment once https://github.com/flowforge/website/pull/736 is merged.
- Cannot merge this until https://github.com/flowforge/website/pull/734 is merged

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes