### PR TITLE
Add details on images to the website handbook

### DIFF
--- a/src/handbook/marketing/website.md
+++ b/src/handbook/marketing/website.md
@@ -24,8 +24,8 @@ Guidelines for including images:
 - Downsize the image to at maximum two times the width it will be displayed (1300px for blog prose)
 - Ideally use JPEG for lossy ok images, and PNG for others (they will be converted to AVIF and WebP regardless)
 - Wherever possible use:
-  - The markdown image include tag `![Name of Image](../relative-path-to-image.jpeg)` in blog prose
-    - You can use the `@skip` tag to disable the image pipeline for this image `![Name of Image](../relative-path-to-image.jpeg "@skip")`
-  - The NJK shortcode `{% image "./relative-path-to-image.png", "Image alt tag for screen readers", [150] %}` in website body
+  - The markdown image include tag in blog prose: `![Name of Image](../relative-path-to-image.jpeg)` 
+    - You can use the `@skip` tag to disable the image pipeline entirely for an image `![Name of Image](../relative-path-to-image.jpeg "@skip")`
+  - The NJK shortcode in website body: {% raw %} `{% image "./relative-path-to-image.png", "Image alt tag for screen readers", [150] %}`{% endraw %}
     - Where 150 is the maximum width the image will be displayed on the page (source image should be two times this width)
 - GIFs can grow incredibly large, consider using a video in a modern format if the animation is longer than a few seconds

--- a/src/handbook/marketing/website.md
+++ b/src/handbook/marketing/website.md
@@ -13,7 +13,7 @@ navTitle: Marketing - Website
 
 #### Images
 
-All images on the website, whether part of the blog or otherwise, are run though an [image pipeline](https://github.com/flowforge/website/blob/main/lib/image-handler.js), that compressed, resizes and converts the images to reduce file size and improve page loading speed.
+All images on the website, whether part of the blog or otherwise, are run though an [image pipeline](https://github.com/flowforge/website/blob/main/lib/image-handler.js), that compresses, resizes and converts the images to reduce file size and improve page loading speed.
 
 That pipeline also generates x2 versions of images for high DPI screens if the provided image is large enough.
 

--- a/src/handbook/marketing/website.md
+++ b/src/handbook/marketing/website.md
@@ -10,3 +10,22 @@ navTitle: Marketing - Website
 - All images should use informative [alt tags](https://www.w3.org/WAI/tutorials/images/tips/) which clearly describe the point of an image rather than all the details. Alt tags should be no longer than 60 characters.
 - When mentioning [FlowForge Concepts](https://flowforge.com/docs/user/concepts/) (terminology) where possible we should link to an explanation of that concept.
 - All written content should use the [Oxford Comma](https://en.wikipedia.org/wiki/Serial_comma). We believe the Oxford Comma reduces the ambiguity of written technical content.
+
+#### Images
+
+All images on the website, whether part of the blog or otherwise, are run though an [image pipeline](https://github.com/flowforge/website/blob/main/lib/image-handler.js), that compressed, resizes and converts the images to reduce file size and improve page loading speed.
+
+That pipeline also generates x2 versions of images for high DPI screens if the provided image is large enough.
+
+The first build locally will take roughly a minute, while the cache remains intact, all future builds should take only a few seconds.
+
+Guidelines for including images:
+
+- Downsize the image to at maximum two times the width it will be displayed (1300px for blog prose)
+- Ideally use JPEG for lossy ok images, and PNG for others (they will be converted to AVIF and WebP regardless)
+- Wherever possible use:
+  - The markdown image include tag `![Name of Image](../relative-path-to-image.jpeg)` in blog prose
+    - You can use the `@skip` tag to disable the image pipeline for this image `![Name of Image](../relative-path-to-image.jpeg "@skip")`
+  - The NJK shortcode `{% image "./relative-path-to-image.png", "Image alt tag for screen readers", [150] %}` in website body
+    - Where 150 is the maximum width the image will be displayed on the page (source image should be two times this width)
+- GIFs can grow incredibly large, consider using a video in a modern format if the animation is longer than a few seconds


### PR DESCRIPTION
## Description

Add details on the image pipeline to handbook.

## Related Issue(s)

From https://github.com/flowforge/website/pull/730, https://github.com/flowforge/website/issues/726 and https://github.com/flowforge/website/issues/721

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [-] Suitable unit/system level tests have been added and they pass
 - [x] Documentation has been updated
