### PR TITLE
Prevent mouse interaction with "FlowForge" in Resources Nav

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -171,7 +171,7 @@
                                     </ul>
                                 </div>
                                 <div class="flex-grow-[2]">
-                                    {% navoption "FlowForge", null, 1, "flowforge", true, "bg-gray-700 border-r border-gray-600" %}{% endnavoption %}
+                                    {% navoption "FlowForge", null, 1, "flowforge", true, "bg-gray-700 border-r border-gray-600 pointer-events-none" %}{% endnavoption %}
                                     <ul class="sm:grid sm:grid-flow-col sm:grid-rows-4 sm:grid-cols-2">
                                         {# {% navoption "getting started", "/blog", 2, "clip-list" %}{% endnavoption %} #}
                                         {% navoption "github", "https://github.com/flowforge/flowforge", 2, "github", true %}{% endnavoption %}


### PR DESCRIPTION
## Description

Adds a missing `pointer-events: none` to the "FlowForge" text int he resources group. This isn't a link, but has hover behaviour to suggest it is.

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes