### PR TITLE
handbook: Add more company details

### DIFF
--- a/src/handbook/company/index.md
+++ b/src/handbook/company/index.md
@@ -15,3 +15,18 @@ continuous, collaborative, and secure manner.
  - [Security](./security.md)
  - [Vision](./vision.md)
  - [Values](./values.md)
+
+## Legal details
+
+### Mailing address
+
+We do not publish our mailing address, it will be distributed on request. Team
+members can find it in the "Company Info" shared vault if they have access.
+
+### Banking details
+
+Upon request wiring details can be provided by the CEO.
+
+### Dun & Bradstreet
+
+FlowForge's Dun and Bradstreet ID is: 11-899-4742


### PR DESCRIPTION
For some customers we need to fill out a form before FlowForge is approved as a vendor. This commit starts recording more details in the handbook to make it easier to complete such forms.