### PR TITLE
misc: Fix broken anchor in link

### DIFF
--- a/src/handbook/peopleops/compensation.md
+++ b/src/handbook/peopleops/compensation.md
@@ -1,6 +1,7 @@
 ---
 navTitle: Compensation
 ---
+
 # Compensation
 
 Total compensation consists of 3 elements, salary, equity, and benefits.
@@ -66,7 +67,7 @@ up to $25.
 
 #### Dinner Bonus
 
-The company's [KPI tracking FlowForge adoption](../company/achieving-success.md#managed-node-red-instances)
+The company's [KPI tracking FlowForge ARR](../company/achieving-success.md#kpi)
 sets an aggressive goal for growth. When the growth target is met a $100 bonus is
 awarded to be expensed for a dinner out. The bonus is awarded per release.
 


### PR DESCRIPTION
When updating the KPI, see also: cf0d7e4cfc2f571614d723da8fe6574e20c1ec90, a anchor changed name. This anchor was linked elsewhere, so that link ended up going to the right page, just not the right section of the page.

This change updates the link to go to the right anchor.
