### PR TITLE
Ensure dataInFuture filter works on the same day

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -131,7 +131,7 @@ module.exports = function(eleventyConfig) {
     eleventyConfig.addFilter('dateInFuture', (date) => {
         // return true is the provided date is in the past, otherwise, return false
         const postDate = spacetime(date)
-        return postDate.isAfter(spacetime.today()) || postDate.isSame(spacetime.today())
+        return postDate.isAfter(spacetime.today()) || postDate.isSame(spacetime.today(), 'day')
     });
 
     eleventyConfig.addFilter('countDays', (date) => {


### PR DESCRIPTION
Fixes #742 - ensures registration form for webinar appears on the same day as the event.

