### PR TITLE
Fix Edge Functions - exclude ELEVENTYEDGE from minification

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -500,6 +500,9 @@ module.exports = function(eleventyConfig) {
                     conservativeCollapse: true,
                     preserveLineBreaks: true,
                     removeComments: true,
+                    ignoreCustomComments: [
+                        /^\s+ELEVENTYEDGE/
+                      ]
                     removeEmptyAttributes: true,
                     removeRedundantAttributes: true,
                     useShortDoctype: true,

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -501,7 +501,7 @@ module.exports = function(eleventyConfig) {
                     preserveLineBreaks: true,
                     removeComments: true,
                     ignoreCustomComments: [
-                        /^\s+ELEVENTYEDGE/
+                        /ELEVENTYEDGE.*/
                     ],
                     removeEmptyAttributes: true,
                     removeRedundantAttributes: true,

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -502,7 +502,7 @@ module.exports = function(eleventyConfig) {
                     removeComments: true,
                     ignoreCustomComments: [
                         /^\s+ELEVENTYEDGE/
-                      ]
+                    ],
                     removeEmptyAttributes: true,
                     removeRedundantAttributes: true,
                     useShortDoctype: true,

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,6 @@ package-lock.json
 .vscode/
 
 # Eleventy Edge Build Data files
-netlify/edge-functions/_generated
+netlify/edge-functions/_generated/
 
 .env

--- a/netlify/edge-functions/_generated/eleventy-edge-app.js
+++ b/netlify/edge-functions/_generated/eleventy-edge-app.js
@@ -1,9 +1,0 @@
-import { EleventyEdge } from "https://cdn.11ty.dev/edge@2.0.2/eleventy-edge.js";
-
-const precompiledAppData = { "eleventy": { "compatibility": ">=2" },
-"buildTimeData": {},
-"nunjucksPrecompiled": {
-  
-} };
-
-export { EleventyEdge, precompiledAppData }


### PR DESCRIPTION
## Description

Excludes the compiled `<!-- ELEVENTYEDGE -->` comments form html minification, which fixes Edge Functions hosted on Netlify.

Also fixes the gitignore to use `/generated/` rather than `/generated` which is generated at build time by Eleventy Edge & Netlify.

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes