### PR TITLE
Image Pipeline: Faux image pipeline in development

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -320,12 +320,16 @@ module.exports = function(eleventyConfig) {
     
     // Eleventy Image shortcode
     // https://www.11ty.dev/docs/plugins/image/
-    console.info(`[11ty] Image pipeline is enabled in ${DEV_MODE ? 'dev mode' : 'prod mode'} expect a wait for first build`)
+    if (DEV_MODE) {
+        console.info(`[11ty] Image pipeline is enabled in dev mode, copying images without any conversion or resizing`)
+    } else {
+        console.info(`[11ty] Image pipeline is enabled in prod mode, expect a wait for first build while images are converted and resized`)
+    }
     eleventyConfig.addAsyncShortcode("image", async function imageShortcode(src, alt, widths, sizes) {
         const title = null
         const currentWorkingFilePath = this.page.inputPath
 
-        return await imageHandler(src, alt, title, widths, sizes, currentWorkingFilePath, eleventyConfig, DEV_MODE)
+        return await imageHandler(src, alt, title, widths, sizes, currentWorkingFilePath, eleventyConfig, async=true, DEV_MODE)
     });
 
     // Create a collection for sidebar navigation

--- a/lib/image-handler.js
+++ b/lib/image-handler.js
@@ -3,6 +3,7 @@ const fs = require("fs")
 
 const eleventyImage = require("@11ty/eleventy-img")
 
+const processedImages = new Set()
 
 /**
  * Is a particular string a URL
@@ -207,6 +208,7 @@ module.exports = function imageHandler(
             path.basename(imgPath)
         )
         const imgOutputURL = path.join(
+            "/",
             path.relative(eleventyOutputFolderPath, imgOutputPath)
         )
 

--- a/lib/image-handler.js
+++ b/lib/image-handler.js
@@ -88,11 +88,6 @@ module.exports = function imageHandler(
             },
         }
     }
-    
-    // Skip slow formats for local development
-    if (DEV_MODE) {
-        formats = formats.filter((format) => !['avif', 'webp'].includes(format))
-    }
 
     // Generate retina images
     const imgWidths = widths.concat(widths.map((w) => (isNaN(w) ? w : w * 2))) // generate 2x sizes (retina)
@@ -104,20 +99,6 @@ module.exports = function imageHandler(
                 (width) =>
                     `(min-device-pixel-ratio: 1.25) ${width * 2}px, (min-resolution: 120dpi) ${width * 2}px, ${width}px`
             )
-
-    // Convert image and grab metadata
-    const imgPath = resolvedImagePath(imgSrc, currentFilePath, eleventyInputFolderPath)
-    const imgOpts = {
-        widths: imgWidths, 
-        formats,
-        outputDir: path.join(eleventyOutputFolderPath, "img"),
-        filenameFormat: function (hash, src, width, format, options) {
-            const { name } = path.parse(src)
-            return `${name}-${hash}-${width}.${format}`
-        },
-        svgShortCircuit: true,
-        ...extraOpts,
-    }
 
     // Skip image parsing if flag is set (@skip in title)
     const parsedTitle = (imgTitle || '').match(
@@ -135,7 +116,50 @@ module.exports = function imageHandler(
     if (parsedTitle.skip || imgSrc.startsWith('http')) {
         const options = { ...htmlOpts }
         const metadata = { img: [{ url: imgSrc }] }
+
         return eleventyImage.generateHTML(metadata, options)
+    }
+
+    // Options for conversion
+    const imgPath = resolvedImagePath(imgSrc, currentFilePath, eleventyInputFolderPath)
+    const imgOpts = {
+        widths: imgWidths, 
+        formats,
+        outputDir: path.join(eleventyOutputFolderPath, "img"),
+        filenameFormat: function (hash, src, width, format, options) {
+            const { name } = path.parse(src)
+            return `${name}-${hash}-${width}.${format}`
+        },
+        svgShortCircuit: true,
+        ...extraOpts,
+    }
+
+    // In dev mode the image pipeline doesn't actually run
+    // Instead it generates HTML picture tags are equivalent of how the pipeline would work
+    // But containing only one, non-converted, resized or compressed, image
+    if (DEV_MODE) {
+        // Naive copy of the image to the output folder
+        const imgOutputPath = path.join(imgOpts.outputDir, path.basename(imgPath))
+        const imgOutputURL = path.relative(eleventyOutputFolderPath, imgOutputPath)
+
+        if (!fs.existsSync(imgOpts.outputDir)) {
+            fs.mkdirSync(imgOpts.outputDir)
+        }
+        fs.copyFileSync(imgPath, imgOutputPath)
+
+        const singleImageMetadata = {
+            url: imgOutputURL,           
+            sourceType: 'image/jpeg', // sourceType is not important for us, but it is for eleventyImage
+        }
+
+        const htmlMetadata = {
+            jpeg: [singleImageMetadata], // tag name must be one of the format understood by eleventyImage
+            img: [singleImageMetadata], // tag name is not important, this is faking a second source
+        }
+
+        htmlOpts.sizes = "100vw, 100vw" // use any source (all have src as undefined so will use IMG tag only)
+
+        return eleventyImage.generateHTML(htmlMetadata, htmlOpts)
     }
 
     // In async mode, image is generated, then stats are read and used to generate HTML

--- a/lib/image-handler.js
+++ b/lib/image-handler.js
@@ -3,6 +3,7 @@ const fs = require("fs")
 
 const eleventyImage = require("@11ty/eleventy-img")
 
+
 /**
  * Is a particular string a URL
  * @param {string} url
@@ -32,7 +33,10 @@ function resolvedImagePath(filePath, workingFilePath, inputFolderPath) {
 
     // Handle both relative to current file and relative to input folder
     try {
-        const resolvedRelativePath = path.resolve(path.dirname(workingFilePath), filePath)
+        const resolvedRelativePath = path.resolve(
+            path.dirname(workingFilePath),
+            filePath
+        )
         if (fs.existsSync(resolvedRelativePath)) {
             return resolvedRelativePath
         }
@@ -44,6 +48,61 @@ function resolvedImagePath(filePath, workingFilePath, inputFolderPath) {
     } catch {}
 
     return filePath
+}
+
+/**
+ * Only copy across file if it is newer than the destination file
+ * @param {*} srcPath
+ * @param {*} destPath
+ * @returns boolean True if file was copiedo
+ */
+async function copyNewerFile(
+    srcPath,
+    destPath,
+    { verbose, interval } = { verbose: false, interval: 1000 }
+) {
+    const stat = fs.statSync(srcPath)
+    if (!stat.isFile()) {
+        // Not a file.
+        throw new Error(`Not supported ${srcPath}`)
+    }
+
+    const srcMTime = stat.mtime
+    let destMTime
+    try {
+        destMTime = (await fs.statSync(destPath)).mtime
+    } catch (err) {
+        // path does not exist
+    }
+
+    if (destMTime !== undefined && srcMTime - destMTime <= interval) {
+        // destPath does not exist or mtime is equal, return.
+        if (verbose) {
+            console.log(`${srcPath} == ${destPath}`)
+        }
+        return false
+    }
+
+    // Commence copying.
+    let rs = fs.createReadStream(srcPath)
+    let ws = fs.createWriteStream(destPath)
+    rs.pipe(ws)
+    await waitForStreamEnd(ws)
+
+    // Set mtime to be equal to the source file.
+    fs.utimesSync(destPath, new Date(), stat.mtime)
+
+    if (verbose) {
+        console.log(`${srcPath} -> ${destPath}`)
+    }
+    return true
+}
+
+async function waitForStreamEnd(stream) {
+    await new Promise((resolve, reject) => {
+        stream.on("error", reject)
+        stream.on("finish", resolve)
+    })
 }
 
 /**
@@ -121,9 +180,13 @@ module.exports = function imageHandler(
     }
 
     // Options for conversion
-    const imgPath = resolvedImagePath(imgSrc, currentFilePath, eleventyInputFolderPath)
+    const imgPath = resolvedImagePath(
+        imgSrc,
+        currentFilePath,
+        eleventyInputFolderPath
+    )
     const imgOpts = {
-        widths: imgWidths, 
+        widths: imgWidths,
         formats,
         outputDir: path.join(eleventyOutputFolderPath, "img"),
         filenameFormat: function (hash, src, width, format, options) {
@@ -139,17 +202,35 @@ module.exports = function imageHandler(
     // But containing only one, non-converted, resized or compressed, image
     if (DEV_MODE) {
         // Naive copy of the image to the output folder
-        const imgOutputPath = path.join(imgOpts.outputDir, path.basename(imgPath))
-        const imgOutputURL = path.relative(eleventyOutputFolderPath, imgOutputPath)
+        const imgOutputPath = path.join(
+            imgOpts.outputDir,
+            path.basename(imgPath)
+        )
+        const imgOutputURL = path.join(
+            path.relative(eleventyOutputFolderPath, imgOutputPath)
+        )
 
-        if (!fs.existsSync(imgOpts.outputDir)) {
-            fs.mkdirSync(imgOpts.outputDir)
+        // Copy image if it hasn't been copied already
+        if (!processedImages.has(imgOutputPath)) {
+            processedImages.add(imgOutputPath)
+
+            // Copying can all happen async, build doesn't need to wait for it to complete
+            new Promise(async (resolve, reject) => {
+                if (!fs.existsSync(imgOpts.outputDir)) {
+                    fs.mkdirSync(imgOpts.outputDir)
+                }
+
+                await copyNewerFile(imgPath, imgOutputPath)
+
+                resolve()
+            }).catch((e) => {
+                console.warn(`Failed copying ${imgPath} to ${imgOutputPath}`)
+            })
         }
-        fs.copyFileSync(imgPath, imgOutputPath)
 
         const singleImageMetadata = {
-            url: imgOutputURL,           
-            sourceType: 'image/jpeg', // sourceType is not important for us, but it is for eleventyImage
+            url: imgOutputURL,
+            sourceType: "image/jpeg", // sourceType is not important for us, but it is for eleventyImage
         }
 
         const htmlMetadata = {


### PR DESCRIPTION
## Description

Fakes an image pipeline when in DEV_MODE (`npm run start`).
PROD_MODE (`npm run build`) still uses the same pipeline.

Images are naively copied over to the output directory, but a `<picture>` tag containing only one image (and two empty `<source>`'s is still used so the HTML is consistent.

This does mean there's a (subtle) difference between production and dev, so please make sure to use the Netlify build preview feature so sanity check ant new images @Yndira-FlowForge @ZJvandeWeg @joepavitt.

## Related Issue(s)

Fixes #632

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [x] Suitable unit/system level tests have been added and they pass
 - [-] Documentation has been updated
