### PR TITLE
Link to Pillar Page in Resources heading

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -140,7 +140,7 @@
                         {% navoption "resources", null, 0 %}
                             <!-- Mobile -->
                             <ul class="block sm:hidden">
-                                {% navoption "FlowForge", "/about", 1, "flowforge", true, "col-span-2" %}
+                                {% navoption "FlowForge", null, 1, "flowforge", true, "col-span-2" %}
                                     <ul class="sm:grid sm:grid-flow-col sm:grid-cols-2 sm:grid-rows-4">
                                         {# {% navoption "getting started", "/blog", 2, "clip-list" %}{% endnavoption %} #}
                                         {% navoption "github", "https://github.com/flowforge/flowforge", 2, "github", true %}{% endnavoption %}
@@ -150,8 +150,9 @@
                                         {% navoption "newsletters", "/community/newsletter", 2, "mail-open" %}{% endnavoption %}
                                     </ul>
                                 {% endnavoption %}
-                                {% navoption "Node-RED", "/node-red/", 1, "nodered" %}
-                                    <ul>
+                                {% navoption "Node-RED", null, 1, "nodered" %}
+                                    <ul class="sm:grid sm:grid-flow-col sm:grid-cols-2 sm:grid-rows-4">
+                                        {% navoption "about", "/node-red/", 2, "info" %}{% endnavoption %}
                                         {% navoption "getting started", "/blog/2023/01/getting-started-with-node-red/", 2, "clip-list" %}{% endnavoption %}
                                         {% navoption "github", "https://github.com/node-red/node-red", 2, "github", true %}{% endnavoption %}
                                         {% navoption "docs", "https://nodered.org/docs/", 2, "document-text" %}{% endnavoption %}
@@ -162,8 +163,9 @@
                             <!-- Desktop -->
                             <ul class="ff-nav-nested-cols hidden bg-gray-600 sm:flex">
                                 <div class="flex-grow">
-                                    {% navoption "Node-RED", "/node-red/", 1, "nodered", false, "bg-gray-700" %}{% endnavoption %}
-                                    <ul>
+                                    {% navoption "Node-RED", null, 1, "nodered", false, "bg-gray-700" %}{% endnavoption %}
+                                    <ul class="sm:grid sm:grid-flow-col sm:grid-rows-5 sm:grid-cols-1 sm:pr-6">
+                                        {% navoption "about", "/node-red/", 2, "info" %}{% endnavoption %}
                                         {% navoption "getting started", "/blog/2023/01/getting-started-with-node-red/", 2, "clip-list" %}{% endnavoption %}
                                         {% navoption "github", "https://github.com/node-red/node-red", 2, "github", true %}{% endnavoption %}
                                         {% navoption "docs", "https://nodered.org/docs/", 2, "document-text" %}{% endnavoption %}
@@ -171,8 +173,8 @@
                                     </ul>
                                 </div>
                                 <div class="flex-grow-[2]">
-                                    {% navoption "FlowForge", "/about", 1, "flowforge", true, "bg-gray-700 border-r border-gray-600" %}{% endnavoption %}
-                                    <ul class="sm:grid sm:grid-flow-col sm:grid-rows-4 sm:grid-cols-2">
+                                    {% navoption "FlowForge", null, 1, "flowforge", true, "bg-gray-700 border-r border-gray-600" %}{% endnavoption %}
+                                    <ul class="sm:grid sm:grid-flow-col sm:grid-rows-5 sm:grid-cols-1 sm:pr-9">
                                         {# {% navoption "getting started", "/blog", 2, "clip-list" %}{% endnavoption %} #}
                                         {% navoption "github", "https://github.com/flowforge/flowforge", 2, "github", true %}{% endnavoption %}
                                         {% navoption "docs", "/docs", 2, "document-text" %}{% endnavoption %}

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -140,7 +140,7 @@
                         {% navoption "resources", null, 0 %}
                             <!-- Mobile -->
                             <ul class="block sm:hidden">
-                                {% navoption "FlowForge", null, 1, "flowforge", true, "col-span-2" %}
+                                {% navoption "FlowForge", "/about", 1, "flowforge", true, "col-span-2" %}
                                     <ul class="sm:grid sm:grid-flow-col sm:grid-cols-2 sm:grid-rows-4">
                                         {# {% navoption "getting started", "/blog", 2, "clip-list" %}{% endnavoption %} #}
                                         {% navoption "github", "https://github.com/flowforge/flowforge", 2, "github", true %}{% endnavoption %}
@@ -150,7 +150,7 @@
                                         {% navoption "newsletters", "/community/newsletter", 2, "mail-open" %}{% endnavoption %}
                                     </ul>
                                 {% endnavoption %}
-                                {% navoption "Node-RED", null, 1, "nodered" %}
+                                {% navoption "Node-RED", "/node-red/", 1, "nodered" %}
                                     <ul>
                                         {% navoption "getting started", "/blog/2023/01/getting-started-with-node-red/", 2, "clip-list" %}{% endnavoption %}
                                         {% navoption "github", "https://github.com/node-red/node-red", 2, "github", true %}{% endnavoption %}
@@ -162,7 +162,7 @@
                             <!-- Desktop -->
                             <ul class="ff-nav-nested-cols hidden bg-gray-600 sm:flex">
                                 <div class="flex-grow">
-                                    {% navoption "Node-RED", null, 1, "nodered", false, "bg-gray-700 pointer-events-none" %}{% endnavoption %}
+                                    {% navoption "Node-RED", "/node-red/", 1, "nodered", false, "bg-gray-700" %}{% endnavoption %}
                                     <ul>
                                         {% navoption "getting started", "/blog/2023/01/getting-started-with-node-red/", 2, "clip-list" %}{% endnavoption %}
                                         {% navoption "github", "https://github.com/node-red/node-red", 2, "github", true %}{% endnavoption %}
@@ -171,7 +171,7 @@
                                     </ul>
                                 </div>
                                 <div class="flex-grow-[2]">
-                                    {% navoption "FlowForge", null, 1, "flowforge", true, "bg-gray-700 border-r border-gray-600 pointer-events-none" %}{% endnavoption %}
+                                    {% navoption "FlowForge", "/about", 1, "flowforge", true, "bg-gray-700 border-r border-gray-600" %}{% endnavoption %}
                                     <ul class="sm:grid sm:grid-flow-col sm:grid-rows-4 sm:grid-cols-2">
                                         {# {% navoption "getting started", "/blog", 2, "clip-list" %}{% endnavoption %} #}
                                         {% navoption "github", "https://github.com/flowforge/flowforge", 2, "github", true %}{% endnavoption %}

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -510,7 +510,7 @@ h4:hover .header-anchor {
     }
 
     .ff-website header .ff-nav-dropdown .ff-nav-nested-cols >div > li {
-        @apply pt-3 pb-2;
+        @apply pt-3 pb-2 pointer-events-none;
     }
     .ff-website header .ff-nav-dropdown .ff-nav-nested-cols >div:first-child > li {
         @apply rounded-tl-lg;
@@ -520,7 +520,7 @@ h4:hover .header-anchor {
     }
 
     .ff-website header .ff-nav-dropdown .ff-nav-nested-cols >div > li > a {
-        @apply py-0;
+        @apply py-0 pointer-events-none;
     }
 
     .ff-website header .ff-nav-dropdown .ff-nav-nested-cols >div:first-child > li > a {

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -506,14 +506,21 @@ h4:hover .header-anchor {
     }
 
     .ff-website header .ff-nav-dropdown .ff-nav-nested-cols ul {
-        @apply my-4;
+        @apply my-3;
     }
 
+    .ff-website header .ff-nav-dropdown .ff-nav-nested-cols >div > li {
+        @apply pt-3 pb-2;
+    }
     .ff-website header .ff-nav-dropdown .ff-nav-nested-cols >div:first-child > li {
-        @apply py-3 rounded-tl-lg;
+        @apply rounded-tl-lg;
     }
     .ff-website header .ff-nav-dropdown .ff-nav-nested-cols >div:last-child > li {
         @apply rounded-tr-lg;
+    }
+
+    .ff-website header .ff-nav-dropdown .ff-nav-nested-cols >div > li > a {
+        @apply py-0;
     }
 
     .ff-website header .ff-nav-dropdown .ff-nav-nested-cols >div:first-child > li > a {


### PR DESCRIPTION
## Description

- Link to `/node-red` from the "Node-RED" header text in the Resources navigation
- To ensure consistency, link to "About FlowForge" from the FlowForge header too.

Request was to have an "About Node-RED" item int he list, but this would make it taller, this was an alternative given the header/text is already there. Easy to switch to initial request if preferred.

## Related Issue(s)

Closes #796 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)