### PR TITLE
Ensure consistent blog tile sizing on /blog

### DIFF
--- a/lib/post-hero-gen.js
+++ b/lib/post-hero-gen.js
@@ -77,5 +77,5 @@ module.exports = function(seed) {
             }
         }
     }
-    return `<svg viewbox="0 0 800 400" class="h-auto w-full" style="background: ${background}"><g fill="none">${content}</g></svg>`
+    return `<svg viewbox="0 0 800 450" class="h-auto w-full" style="background: ${background}"><g fill="none">${content}</g></svg>`
 }

--- a/src/blog.njk
+++ b/src/blog.njk
@@ -9,7 +9,7 @@ pagination:
 meta:
     title: Blog
 ---
-<div class="container m-auto text-left max-w-4xl pb-24 w-full">
+<div class="ff-blog container m-auto text-left max-w-4xl pb-24 w-full">
     <div class="px-2">
         <h1>Blog</h1>
         <div class="md:-mt-6">
@@ -34,7 +34,7 @@ meta:
                     </div>
                 </div>
                 <div class="flex flex-col md:flex-row">
-                    <div class="pr-2 md:w-1/3">
+                    <div class="ff-blog-tile pr-2 md:w-1/3">
                         {% if item.data.image %}
                             <div class="w-full h-auto">
                                 {% set imageSrc = ["./", item.data.image ] | join %}
@@ -76,7 +76,7 @@ meta:
             <a href="{{ item.url }}" class="w-full flex flex-col group hover:no-underline">
                 <div class="">
                     <time class="block text-xs mb-2" value="{{ item.date }}" class="text-gray-400">{{ item.date | shortDate }}</time>
-                    <div>
+                    <div class="ff-blog-tile">
                         {% if item.data.image %}
                             <div class="w-full h-auto">
                                 {% set imageSrc = ["./", item.data.image ] | join %}

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -541,6 +541,17 @@ h4:hover .header-anchor {
 }
 
 /*
+    Specific Page Styling
+*/
+@layer components {
+    .ff-blog-tile img,
+    .ff-blog-tile svg {
+        object-fit: cover;
+        aspect-ratio: 1.78
+    }
+}
+
+/*
     Footer
 */
 @layer components {


### PR DESCRIPTION
## Description

- Enforce `aspect-ratio` and `object-cover` for img and svg tiles
- Update the SVG generator to align with the 1.78 A/R we use.

<img width="1031" alt="Screenshot 2023-06-01 at 13 39 12" src="https://github.com/flowforge/website/assets/99246719/d23f150e-e813-47ee-aa35-0c24f3ee5ad0">

## Related Issue(s)

Fixes #452

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)