### PR TITLE
Add "on the roadmap" tooltip for features table

### DIFF
--- a/src/_includes/feature_lists/cloud.njk
+++ b/src/_includes/feature_lists/cloud.njk
@@ -163,7 +163,9 @@
                 {% if value === "check" %}
                 {% include "components/feature-check.svg" %}
                 {% elif value === "time" %}
-                {% include "components/feature-time.svg" %}
+                {% tooltip "On the roadmap" %}
+                    {% include "components/feature-time.svg" %}
+                {% endtooltip %}
                 {% elif value === "optional" %}
                 {% include "components/feature-optional.svg" %}
                 {% elif value === "addon" %}

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -946,6 +946,7 @@ h4:hover .header-anchor {
         width: 100%;
         text-align: left;
         font-weight: bold;
+        z-index: 1;
     }
     
     li.ff-feature--header span {


### PR DESCRIPTION
## Description

- Adds tooltips to the features table on the /pricing page

Couldn't find any other obvious places for the tooltips to be added, so this can close #548 until we find more.

## Related Issue(s)

Closes #548 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes