### PR TITLE
Load algolia only on handbook & docs

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -376,21 +376,4 @@ gtag('js', new Date());
 
 gtag('config', 'G-2ZH9W82QL8');
 </script>
-
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@algolia/algoliasearch-netlify-frontend@1/dist/algoliasearchNetlify.css" />
-<link
-  rel="stylesheet"
-  href="https://cdn.jsdelivr.net/npm/@algolia/autocomplete-theme-classic"
-/>
-<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/@algolia/algoliasearch-netlify-frontend@1/dist/algoliasearchNetlify.js"></script>
-<script type="text/javascript">
-  algoliasearchNetlify({
-    appId: 'KWE0727TZS',
-    apiKey: '595ee07f069991380e9c3036cfad8e5e',
-    siteId: '00f8cf60-997f-4c4d-9427-a97924358648',
-    branch: 'live',
-    selector: 'div#algolia-search',
-    detached: false
-  });
-</script>
 </html>

--- a/src/_includes/layouts/handbook.njk
+++ b/src/_includes/layouts/handbook.njk
@@ -194,19 +194,19 @@ date: git Last Modified
 <link rel="preload" href="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/themes/prism-tomorrow.min.css" as="style" onload="this.onload=null;this.rel='stylesheet'" crossorigin="anonymous" referrerpolicy="no-referrer" />
 
 
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@algolia/algoliasearch-netlify-frontend@1/dist/algoliasearchNetlify.css" />
-<link
-  rel="stylesheet"
-  href="https://cdn.jsdelivr.net/npm/@algolia/autocomplete-theme-classic"
-/>
-<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/@algolia/algoliasearch-netlify-frontend@1/dist/algoliasearchNetlify.js"></script>
-<script type="text/javascript">
-  algoliasearchNetlify({
-    appId: 'KWE0727TZS',
-    apiKey: '595ee07f069991380e9c3036cfad8e5e',
-    siteId: '00f8cf60-997f-4c4d-9427-a97924358648',
-    branch: 'live',
-    selector: 'div#algolia-search',
-    detached: false
-  });
+<link rel="preload"href="https://cdn.jsdelivr.net/npm/@algolia/algoliasearch-netlify-frontend@1/dist/algoliasearchNetlify.css" as="style" onload="this.onload=null;this.rel='stylesheet'" crossorigin="anonymous" referrerpolicy="no-referrer" />
+<link rel="preload" href="https://cdn.jsdelivr.net/npm/@algolia/autocomplete-theme-classic" as="style" onload="this.onload=null;this.rel='stylesheet'" crossorigin="anonymous" referrerpolicy="no-referrer" />
+
+<script async type="text/javascript" src="https://cdn.jsdelivr.net/npm/@algolia/algoliasearch-netlify-frontend@1/dist/algoliasearchNetlify.js" onload="initSearchBar()"></script>
+<script async type="text/javascript">
+  function initSearchBar () {
+    algoliasearchNetlify({
+        appId: 'KWE0727TZS',
+        apiKey: '595ee07f069991380e9c3036cfad8e5e',
+        siteId: '00f8cf60-997f-4c4d-9427-a97924358648',
+        branch: 'live',
+        selector: 'div#algolia-search',
+        detached: false
+    });
+    }
 </script>

--- a/src/_includes/layouts/handbook.njk
+++ b/src/_includes/layouts/handbook.njk
@@ -193,3 +193,20 @@ date: git Last Modified
 <!-- Syntax Highlighting CSS -->
 <link rel="preload" href="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/themes/prism-tomorrow.min.css" as="style" onload="this.onload=null;this.rel='stylesheet'" crossorigin="anonymous" referrerpolicy="no-referrer" />
 
+
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@algolia/algoliasearch-netlify-frontend@1/dist/algoliasearchNetlify.css" />
+<link
+  rel="stylesheet"
+  href="https://cdn.jsdelivr.net/npm/@algolia/autocomplete-theme-classic"
+/>
+<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/@algolia/algoliasearch-netlify-frontend@1/dist/algoliasearchNetlify.js"></script>
+<script type="text/javascript">
+  algoliasearchNetlify({
+    appId: 'KWE0727TZS',
+    apiKey: '595ee07f069991380e9c3036cfad8e5e',
+    siteId: '00f8cf60-997f-4c4d-9427-a97924358648',
+    branch: 'live',
+    selector: 'div#algolia-search',
+    detached: false
+  });
+</script>


### PR DESCRIPTION
## Description

Fixes issue raised in the Lighthouse Reporting:

<img width="931" alt="Screenshot 2023-06-02 at 15 53 43" src="https://github.com/flowforge/website/assets/99246719/c1f00a05-fde5-4b26-9e53-340802214a12">

- Algolia scripts were _always_ loaded
- Only required on Handbook & Docs pages for the search bar.

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes