### PR TITLE
Revert "Remove edge function declaration"

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -13,3 +13,7 @@ package = "@algolia/netlify-plugin-crawler"
   [plugins.inputs]
   branches = ['main', 'live']
   template = "hierarchical"
+  
+[[edge_functions]]
+function = "eleventy-edge"
+path = "/*"


### PR DESCRIPTION
This reverts commit 55be827468d07b735a09e4552fe806e0445fee57.

## Description

Netlify have fixed edge functions outage - reverting the change to include them again.

## Related Issue(s)

Revert https://github.com/flowforge/website/pull/833

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)