### PR TITLE
Node-Red page fix: removed extra div

### DIFF
--- a/src/node-red.njk
+++ b/src/node-red.njk
@@ -74,7 +74,6 @@ sitemapPriority: 0.8
         </div>
     </div>
 
-   <div class="about w-full bg-white">
     <div class="w-full ff-bg-light pt-8 px-0 pb-12 ff-prose">
         <div class="text-center md:mt-12 mb-6">
             <h2>What is Node-RED?</h2>


### PR DESCRIPTION
There was an extra `<div>` tag that was preventing some dividers from displaying properly