### PR TITLE
misc: Better timestamp for last handbook update

### DIFF
--- a/src/_includes/layouts/handbook.njk
+++ b/src/_includes/layouts/handbook.njk
@@ -125,7 +125,7 @@ date: git Last Modified
                 {% renderTeamMember maintainer %}
             {%- endfor -%}
             <div class="text-sm pb-1 text-right mb-4"><a href="{{ page | handbookEditLink }}">Edit this page</a></div>
-            <div class="text-xs pb-1 text-right mb-4 italic">Updated: {{ page.date }}</div>
+            <div class="text-xs pb-1 text-right mb-4 italic">Updated: {{ page.date | shortDate }}</div>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Description

I was annoyed by how correct the updated at was in the handbook, took up a lot of space and didn't tell me much more information I needed.

#### Before

![Screenshot 2023-06-21 at 11 32 23](https://github.com/flowforge/website/assets/2529595/c37deed9-bf18-4a9b-a4f4-ed1024b64df7)

#### After

![Screenshot 2023-06-21 at 11 32 11](https://github.com/flowforge/website/assets/2529595/ae17e235-f5fa-43e1-833d-bf2dc91b5729)

