### PR TITLE
SOC: Add code of conduct

### DIFF
--- a/src/handbook/peopleops/code-of-conduct.md
+++ b/src/handbook/peopleops/code-of-conduct.md
@@ -1,0 +1,121 @@
+---
+navTitle: Code of Conduct
+---
+
+## Code of Conduct
+
+The primary goal of our Code of Conduct is to foster inclusive, collaborative
+and safe working conditions for all FlowForge staff. As such, FlowForge is
+committed to providing a friendly, safe and welcoming environment for all staff,
+regardless of gender, sexual orientation, ability, ethnicity, socioeconomic status,
+or religion (or lack thereof).
+
+This code of conduct outlines our expectations for all FlowForge staff, as well
+as the consequences for unacceptable behavior.
+
+### Scope 
+
+The Code of Conduct applies to all FlowForge staff. This includes full-time,
+part-time and contractor staff employed at every seniority level. The Code of
+Conduct is to be upheld during all professional functions and events, including
+but not limited to:
+
+ - Working remotely and communicating on FlowForge resources with other team members.
+ - At FlowForge-related extracurricular activities and events.
+ - While attending conferences and other professional events on behalf of FlowForge.
+ 
+We expect all FlowForge staff to abide by this Code of Conduct in all business
+matters -- online and in-person -- as well as in all one-on-one communications
+with customers and staff pertaining to FlowForge business.
+
+This Code of Conduct also applies to unacceptable behavior occurring outside the
+scope of business activities when such behavior has the potential to adversely
+affect the safety and well-being of FlowForge staff and clients.
+
+### Culture and Citizenship
+
+A supplemental goal of this Code of Conduct is to increase open citizenship by
+encouraging participants to recognize the relationships between our actions and
+their effects within FlowForge culture.
+
+At the core are our [company values](../company/values.md). This Code of Conduct
+makes explict how we should behave whilst uphold our values.
+
+ - **Be inclusive**. We strive to be a company that welcomes and supports people
+   of all backgrounds and identities. This includes, but is not limited to members
+   of any race, ethnicity, culture, national origin, color, immigration status,
+   social and economic class, educational level, sexual orientation, gender
+   identity and expression, age, size, family status, political belief, religion,
+   and mental and physical ability.
+ - **Be considerate**. Your work at FlowForge will be used by other people, and
+   you in turn will depend on the work of others. Any decision you take will
+   affect users and colleagues, and you should take those consequences into account
+   when making decisions.
+ - **Be respectful**. Not all of us will agree all the time, but disagreement is
+   no excuse for poor behavior and poor manners. We might all experience some
+   frustration now and then, but we cannot allow that frustration to turn into a
+   personal attack. It’s important to remember that a company where people feel
+   uncomfortable or threatened is neither productive nor pleasant. FlowForge staff
+   should always be respectful when dealing with other personnel as well as with
+   people outside of FlowForge employment.
+
+### Acceptable and Expected Behavior
+
+The following behaviors are expected and requested of all FlowForge staff:
+
+ - Participate in an authentic and active way. In doing so, you contribute to the
+   health and longevity of FlowForge.
+ - Exercise consideration and respect in your speech and actions at all times.
+ - Attempt collaboration before conflict.
+ - Refrain from demeaning, discriminatory, or harassing behavior and speech.
+ - Be mindful of your surroundings and of your fellow participants. Alert FlowForge
+   leaders if you notice a dangerous situation, someone in distress, or violations
+   of this Code of Conduct, even if they seem inconsequential.
+
+### Unacceptable Behavior
+
+The following behaviors are considered harassment and are unacceptable within our community:
+
+ - Violence, threats of violence or violent language directed against another person.
+ - Sexist, racist, homophobic, transphobic, ableist or otherwise discriminatory jokes and language.
+ - Posting or displaying sexually explicit or violent material.
+ - Posting or threatening to post other people’s personally identifying information ("doxing").
+ - Personal insults, particularly those related to gender, sexual orientation, race, religion, or disability.
+ - Inappropriate photography or recording.
+ - Inappropriate physical contact. You should have someone’s consent before touching them in any manner.
+ - Unwelcome sexual attention. This includes sexualized comments or jokes; inappropriate touching, groping, and unwelcome sexual advances.
+ - Deliberate intimidation, stalking or following (online or in person).
+ - Advocating for, or encouraging, any of the above behavior.
+ - Repeated harassment of others. In general, if someone asks you to stop, then stop.
+ - Other conduct which could reasonably be considered inappropriate in a professional setting.
+
+### Consequences of Unacceptable Behavior
+
+Unacceptable behavior from any FlowForge staff, including those with
+decision-making authority, will not be tolerated.
+
+Anyone asked to stop unacceptable behavior is expected to comply immediately.
+
+If a staff member engages in unacceptable behavior, FlowForge leadership may take
+any action deemed appropriate, up to and including suspension or termination.
+
+### Reporting Violations
+
+If you are subject to or witness unacceptable behavior, or have any other concerns,
+please notify an appropriate member of FlowForge leadership as soon as possible.
+
+It is a violation of this policy to retaliate against any person making a
+complaint of Unacceptable Behavior or against any person participating in the
+investigation of (including testifying as a witness to) any such allegation. Any
+retaliation or intimidation may be subject to punitive action up to and including
+termination.
+
+### Disciplinary Action
+
+Employees who violate this policy may face disciplinary consequences in proportion
+to their violation. FlowForge management will determine how serious an employee's
+offense is and take the appropriate action
+
+### Responsibility
+
+Everyone has a responsibility to ensure this policy is followed.

--- a/src/handbook/peopleops/code-of-conduct.md
+++ b/src/handbook/peopleops/code-of-conduct.md
@@ -76,8 +76,8 @@ The following behaviors are expected and requested of all FlowForge staff:
 
 The following behaviors are considered harassment and are unacceptable within our community:
 
- - Violence, threats of violence or violent language directed against another person.
- - Sexist, racist, homophobic, transphobic, ableist or otherwise discriminatory jokes and language.
+ - Violence, threats of violence, or violent language directed against another person.
+ - Sexist, racist, homophobic, transphobic, [ableist](https://en.wikipedia.org/wiki/Ableism) or otherwise discriminatory jokes and language.
  - Posting or displaying sexually explicit or violent material.
  - Posting or threatening to post other people’s personally identifying information ("doxing").
  - Personal insults, particularly those related to gender, sexual orientation, race, religion, or disability.
@@ -102,7 +102,7 @@ any action deemed appropriate, up to and including suspension or termination.
 ### Reporting Violations
 
 If you are subject to or witness unacceptable behavior, or have any other concerns,
-please notify an appropriate member of FlowForge leadership as soon as possible.
+please notify an appropriate member of FlowForge leadership (Peopleops manager, CTO, and/or CEO) as soon as possible.
 
 It is a violation of this policy to retaliate against any person making a
 complaint of Unacceptable Behavior or against any person participating in the
@@ -114,7 +114,7 @@ termination.
 
 Employees who violate this policy may face disciplinary consequences in proportion
 to their violation. FlowForge management will determine how serious an employee's
-offense is and take the appropriate action
+offense is and take the appropriate action.
 
 ### Responsibility
 

--- a/src/handbook/peopleops/code-of-conduct.md
+++ b/src/handbook/peopleops/code-of-conduct.md
@@ -5,20 +5,24 @@ navTitle: Code of Conduct
 ## Code of Conduct
 
 The primary goal of our Code of Conduct is to foster inclusive, collaborative
-and safe working conditions for all FlowForge staff. As such, FlowForge is
-committed to providing a friendly, safe and welcoming environment for all staff,
-regardless of gender, sexual orientation, ability, ethnicity, socioeconomic status,
-or religion (or lack thereof).
+and safe working conditions for all FlowForge staff and community members who
+participate in our open core projects.
 
-This code of conduct outlines our expectations for all FlowForge staff, as well
-as the consequences for unacceptable behavior.
+As such, FlowForge is committed to providing a friendly, safe and welcoming
+environment regardless of gender, sexual orientation, ability, ethnicity,
+socioeconomic status, or religion (or lack thereof).
+
+This code of conduct outlines our expectations for the FlowForge community, as
+well as the consequences for unacceptable behavior.
 
 ### Scope 
 
 The Code of Conduct applies to all FlowForge staff. This includes full-time,
-part-time and contractor staff employed at every seniority level. The Code of
-Conduct is to be upheld during all professional functions and events, including
-but not limited to:
+part-time and contractor staff employed at every seniority level. It also applies
+to contributors who engage with our open core projects.
+
+The Code of Conduct is to be upheld during all professional functions and events,
+including but not limited to:
 
  - Working remotely and communicating on FlowForge resources with other team members.
  - At FlowForge-related extracurricular activities and events.
@@ -32,32 +36,25 @@ This Code of Conduct also applies to unacceptable behavior occurring outside the
 scope of business activities when such behavior has the potential to adversely
 affect the safety and well-being of FlowForge staff and clients.
 
-### Culture and Citizenship
+### Culture and Belonging
 
-A supplemental goal of this Code of Conduct is to increase open citizenship by
+A supplemental goal of this Code of Conduct is to increase open community by
 encouraging participants to recognize the relationships between our actions and
 their effects within FlowForge culture.
 
 At the core are our [company values](../company/values.md). This Code of Conduct
 makes explict how we should behave whilst uphold our values.
 
- - **Be inclusive**. We strive to be a company that welcomes and supports people
-   of all backgrounds and identities. This includes, but is not limited to members
-   of any race, ethnicity, culture, national origin, color, immigration status,
-   social and economic class, educational level, sexual orientation, gender
-   identity and expression, age, size, family status, political belief, religion,
-   and mental and physical ability.
- - **Be considerate**. Your work at FlowForge will be used by other people, and
-   you in turn will depend on the work of others. Any decision you take will
-   affect users and colleagues, and you should take those consequences into account
-   when making decisions.
+ - [**Be inclusive**](../company/values.md#👥-collaborative-community). We strive
+   to be a company that welcomes and supports people of all backgrounds and identities.
+ - [**Be considerate**](../company/values.md#🤝-customer-empathy). Your work at
+   FlowForge will be used by other people, and you in turn will depend on the
+   work of others. Any decision you take will affect users and colleagues, and
+   you should take those consequences into account when making decisions.
  - **Be respectful**. Not all of us will agree all the time, but disagreement is
-   no excuse for poor behavior and poor manners. We might all experience some
-   frustration now and then, but we cannot allow that frustration to turn into a
-   personal attack. It’s important to remember that a company where people feel
-   uncomfortable or threatened is neither productive nor pleasant. FlowForge staff
-   should always be respectful when dealing with other personnel as well as with
-   people outside of FlowForge employment.
+   no excuse for poor behavior and poor manners. We expect everyone to remain polite
+   and to keep conversations healthy and constructive. We do not allow our frustrations
+   to turn in [personal attacks](https://en.wikipedia.org/wiki/Ad_hominem).
 
 ### Acceptable and Expected Behavior
 

--- a/src/handbook/peopleops/index.md
+++ b/src/handbook/peopleops/index.md
@@ -7,6 +7,7 @@ navGroup: Internal Operations
 
 People operations contains information on HR related policies at FlowForge.
 
+- [Code of Conduct](./code-of-conduct.md)
 - [Compensation](./compensation.md)
 - [Expenses](./expenses.md)
 - [Hiring](./hiring.md)


### PR DESCRIPTION
## Description

Having an approved code of conduct is strongly suggested as part of SOC compliance.

I have largely used the template from Vanta as I believe it covers the bases well. There is some overlap with our values here - which I've added links to as needed. But this is a bit more explicit on some of the items in our Values statement. It didn't feel right to add all of that detail to the Values doc at this stage - but open to feedback on that.

Although it comes from the SOC requirement, I've put the doc in our peopleops section, rather than with the other security policies as that feels the right place for it to live.