### PR TITLE
Hide the events banner

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -93,7 +93,7 @@
     <div class="flex-grow base">
         <div class="w-full">
             <!-- Events Banner -->
-            {% include "../components/events-banner.njk" %}
+            <!-- {% include "../components/events-banner.njk" %} -->
             <!-- Navigation Header -->
             <header id="ff-header" class="ff-header">
                 <nav class="relative w-full flex items-center justify-between mx-auto container md:max-w-screen-xl">


### PR DESCRIPTION
## Description

We don't currently have an event to invite our visitors to register to, so we're hiding the events banner until we do

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
