### PR TITLE
fix: Add date value to HTML element

### DIFF
--- a/src/_includes/layouts/post.njk
+++ b/src/_includes/layouts/post.njk
@@ -64,7 +64,7 @@ layout: layouts/base.njk
                             {% renderTeamMember people[author] %}
                         {% endif %}
                     {% endfor %}
-                    <p>Published on: <time value="{{ item.date }}">{{ date  | shortDate }}</time></p>
+                    <p>Published on: <time value="{{ date | dateToRfc3339 }}">{{ date  | shortDate }}</time></p>
                     <h3 class="mb-3 pt-6 border-t-2">Recommended Articles:</h3>
                     <ul class="ml-6 list-disc">
                     {% for post in collections.posts | reverse | limit(5) %}


### PR DESCRIPTION
The element was empty, as item.date is undefined. The string interpolation created the empty string instead. With this page the value is filled.
