### PR TITLE
Remove Youtube release videos from Content Channels table

### DIFF
--- a/src/handbook/marketing/channels.md
+++ b/src/handbook/marketing/channels.md
@@ -8,7 +8,7 @@ Each content type has channels which are appropriate, this table sets out which 
 
 |Content          |Blog  |Mailing List |Twitter  |Youtube  |LinkedIn |Reddit |Node-RED Slack|Node-RED Discourse  |
 |---              |---   |---          |---      |---      |---      |---    |---           |---               |
-|Release          |*     |             |*        |*        |*        |*      |*             |*                 |
+|Release          |*     |             |*        |         |*        |*      |*             |*                 |
 |Patch            |*     |             |*        |         |         |*      |*             |                  | 
 |Planned Downtime |*     |             |*        |         |*        |*      |*             |                  |
 |Outage           |      |             |         |         |         |       |              |                  |


### PR DESCRIPTION
## Description

After a discussion on the marketing meeting, I have removed YT as a channel we post release content to as we are no longer doing release videos.
