### PR TITLE
fix indentation for meta description in pricing page

### DIFF
--- a/src/pricing.njk
+++ b/src/pricing.njk
@@ -4,7 +4,7 @@ align: center
 layout: layouts/page.njk
 sitemapPriority: 0.90
 meta:
-description: Find out how much it costs to use FlowForge.
+    description: Find out how much it costs to use FlowForge.
 ---
 
 <div class="px-6 pricing-tiles flex flex-col mb-16 md:max-w-screen-lg">


### PR DESCRIPTION
## Description

fix indentation for meta description in pricing page

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
