### PR TITLE
Removes excess padding at top of docs & handbook

### DIFF
--- a/src/_includes/layouts/nohero.njk
+++ b/src/_includes/layouts/nohero.njk
@@ -2,6 +2,6 @@
 layout: layouts/page.njk
 nohero: true
 ---
-<div class="nohero w-full pt-8 md:pt-12 ff-bg-light">
+<div class="nohero w-full ff-bg-light">
     {{ content | safe }}
 </div>


### PR DESCRIPTION
## Description

Excess padding/white space looks odd at the top of handbook & docs. Think this is an artefact of the webinar banner being temporarily removed (whilst we don't have an upcoming webinar).

### Before:

<img width="1177" alt="Screenshot 2023-07-06 at 10 14 30" src="https://github.com/flowforge/website/assets/99246719/268835e1-3365-42a9-a277-d60c74e1b343">

### After:

<img width="1179" alt="Screenshot 2023-07-06 at 10 14 20" src="https://github.com/flowforge/website/assets/99246719/c9d45079-66aa-4320-9099-c790966f7e37">

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)