### PR TITLE
Add trailing / to /docs and /handbook links in nav

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -152,7 +152,7 @@
                                 {% navoption "about", "/about", 1, "info" %}{% endnavoption %}
                                 {% navoption "blog", "/blog", 1, "newspaper" %}{% endnavoption %}
                                 {% navoption "team", "/team", 1, "users" %}{% endnavoption %}
-                                {% navoption "handbook", "/handbook", 1, "star" %}{% endnavoption %}
+                                {% navoption "handbook", "/handbook/", 1, "star" %}{% endnavoption %}
                                 {% navoption "jobs", "https://boards.greenhouse.io/flowforge", 1, "case" %}{% endnavoption %}
                                 {% navoption "support", "/support", 1, "chat" %}{% endnavoption %}
                                 {% navoption "contact us", "/contact-us", 1, "mail" %}{% endnavoption %}
@@ -208,7 +208,7 @@
                                 </div>
                             </ul>
                         {% endnavoption %}
-                        {% navoption "docs", "/docs", 0, false %}{% endnavoption %}
+                        {% navoption "docs", "/docs/", 0, false %}{% endnavoption %}
                     </ul>
 
                     <ul class="hidden top-8 right-0 border shadow-sm md:inline md:shadow-none w-36 z-10 md:border-0 bg-white md:bg-transparent md:w-auto rounded md:static md:float-none md:flex md:flex-row flex-col items-center justify-end font-medium text no-underline">


### PR DESCRIPTION
## Description

When developing locally, clicking "docs" or "handbook" in the top nav bar takes us to `/docs` and `/handbook` respectively. The problem here is that a lot of the local linking on the homepages within these resources use `./page` notation, which, given the lack of trailing slash at the current URL, means we end up with a 404. This doesn't occur in production because Netlify auto-redirects traffic from `/any-path-here` to `/any-path-here/`

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
