### PR TITLE
Fix "home" link on Left Nav

### DIFF
--- a/src/_includes/layouts/left-nav.njk
+++ b/src/_includes/layouts/left-nav.njk
@@ -1,8 +1,7 @@
 <!-- Navigation -->
 <div class="border-r" data-{{nav}}>
     <ul class="handbook-nav" data-el="navigation">
-        {%- set path = nav -%}
-        {% set path = ["node-red/", path] | join if nav == "core-nodes" %}
+        {% set path = (["node-red/", path] | join) if nav == "core-nodes" else nav %}
 
         <li class="{% if "/{{ path }}/" === page.url %}active{% endif %}">
             <a href="/{{ path }}">{{ nav }}</a>

--- a/src/_includes/layouts/left-nav.njk
+++ b/src/_includes/layouts/left-nav.njk
@@ -1,7 +1,7 @@
 <!-- Navigation -->
 <div class="border-r" data-{{nav}}>
     <ul class="handbook-nav" data-el="navigation">
-        {% set path = (["node-red/", path] | join) if nav == "core-nodes" else nav %}
+        {% set path = (["node-red/", nav] | join) if nav == "core-nodes" else nav %}
 
         <li class="{% if "/{{ path }}/" === page.url %}active{% endif %}">
             <a href="/{{ path }}">{{ nav }}</a>


### PR DESCRIPTION
## Description

Regression introduced in https://github.com/flowforge/website/pull/911/ meant that the "docs" and "handbook" links at the top of the left navigation were just going to our homepage.

Problem was a missing `else` in the ternary operator.

Can confirm that this link now works across all of handbook, docs and core-nodes documentation.

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
