### PR TITLE
Redirect support for group index & navOrder to control left nav option

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -414,7 +414,7 @@ module.exports = function(eleventyConfig) {
             let groups = {
                 'Other': {
                     name: 'Other',
-                    order: -1,    // always render last
+                    order: Number.MAX_SAFE_INTEGER,    // always render last
                     children: []
                 }
             }

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -373,7 +373,7 @@ module.exports = function(eleventyConfig) {
                         accumulator[currentValue] = {
                             'name': currentValue,
                             'url': page.data.redirect || page.url,
-                            'order': page.data.navOrder || 0,
+                            'order': page.data.navOrder || Number.MAX_SAFE_INTEGER,
                             'children': {}
                         }
                         if (page.data.navTitle) {

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -372,7 +372,8 @@ module.exports = function(eleventyConfig) {
                     if (!accumulator[currentValue]) {
                         accumulator[currentValue] = {
                             'name': currentValue,
-                            'url': page.url,
+                            'url': page.data.redirect || page.url,
+                            'order': page.data.navOrder || 0,
                             'children': {}
                         }
                         if (page.data.navTitle) {
@@ -439,7 +440,7 @@ module.exports = function(eleventyConfig) {
 
                 function sortChildren (a, b) {
                     // sort children by 'order', then alphabetical
-                    return b.order - a.order || a.name.localeCompare(b.name)
+                    return (b.order - a.order) || a.name.localeCompare(b.name)
                 }
 
                 nav[tag].groups = Object.values(groups).sort(sortChildren)

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -440,7 +440,7 @@ module.exports = function(eleventyConfig) {
 
                 function sortChildren (a, b) {
                     // sort children by 'order', then alphabetical
-                    return (b.order - a.order) || a.name.localeCompare(b.name)
+                    return (a.order - b.order) || a.name.localeCompare(b.name)
                 }
 
                 nav[tag].groups = Object.values(groups).sort(sortChildren)


### PR DESCRIPTION
## Description

- `navOrder` can now be set in the frontmatter for an `.md` file, and it will affect the order in which the page appears in the left-side navigation. The higher the number, the more priority it gets at being shown first.
- Added `redirect` as a frontmatter property too. This meant that we could redirect to a given child when a group (.e.g "Device Agent" is clicked, rather than having to have multiple `README.md` files with just a table of content. In this case we can redirect to a `Getting Started` or `Introduction` child.

## Related Issue(s)

Will be opening a FF PR shortly with the first batch of docs changes that utilise these and will backlink once I've got that opened.

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
