### PR TITLE
redirect from /docs/user/devices/ to /docs/user/device-agent/introduction

### DIFF
--- a/src/redirect.md
+++ b/src/redirect.md
@@ -26,6 +26,7 @@ redirects:
   - { "from": "/roadmap/", "to": "/product/roadmap/" }
   - { "from": "/handbook/development/release/", "to": "/handbook/development/releases/" }
   - { "from": "/blog/2023/06/Flowforge-as-a-No-Code-Ethernet_IP-to-Profinet-Protocol-Converter/", "to": "/blog/2023/06/Node-RED-as-a-No-Code-Ethernet_IP-to-S7-Protocol-Converter/" }
+  - { "from": "/docs/user/devices/", "to": "/docs/device-agent/introduction" }
 # The "permalink" attribute determines where the output page will be located.
 permalink: "{{ redirect.from }}"
 # The "redirect" layout just has a small html header with the meta tags that do redirection.


### PR DESCRIPTION
## Description

We've re-organised some of the documentation, and as such, no longer have a `/docs/user/devices/` endpoint, this adds a redirect to ensure users to to the right place.

## Related Issue(s)

For use when https://github.com/flowforge/flowforge/pull/2457 is merged

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
     - Tested locally, redirect works as expected.
