### PR TITLE
Better control over the section ordering in documentation

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -349,6 +349,14 @@ module.exports = function(eleventyConfig) {
         createNav('core-nodes')
 
         function createNav(tag) {
+            const groupOrder = {
+                docs: [
+                    'Overview',
+                    'Device Agent',
+                    'Running FlowForge'
+                ]
+            }
+
             collection.getFilteredByTag(tag).filter((page) => {
                 return !page.url.includes('README')
             }).sort((a, b) => {
@@ -427,7 +435,7 @@ module.exports = function(eleventyConfig) {
                         if (!groups[group]) {
                             groups[group] = {
                                 name: group,
-                                order: 0,
+                                order: groupOrder[tag] && groupOrder[tag].includes(group) ? groupOrder[tag].indexOf(group) : Number.MAX_SAFE_INTEGER,
                                 children: []
                             }
                         }


### PR DESCRIPTION
## Description

As we've now split the documentation into new sections, we desire control over the ordering of said sections, that wasn't necessary with the Core Nodes or handbook documentation (which order alphabetically)

This change introduces a new map in the `createNav` function which stores an ordered list of the sections in an array. The `order` value for a section is then determined by the index in that array, or falls back to `MAX_INT`, and will show at the bottom (then by alpha if multiple here).

**Now:**

<img width="345" alt="Screenshot 2023-07-11 at 18 28 33" src="https://github.com/flowforge/website/assets/99246719/aa0e7b49-73c4-4991-8f9b-d14cda2d6c57">

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] I have considered the performance impact of these changes
