### PR TITLE
Use updated meta data if present to ensure sidebar shows right date

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -104,7 +104,7 @@ module.exports = function(eleventyConfig) {
     });
 
     eleventyConfig.addFilter('shortDate', dateObj => {
-        return spacetime(dateObj).format('{date} {month-short}, {year}')
+        return spacetime(new Date(dateObj)).format('{date} {month-short}, {year}')
     });
 
     eleventyConfig.addFilter('duration', mins => {

--- a/src/_includes/layouts/handbook.njk
+++ b/src/_includes/layouts/handbook.njk
@@ -66,7 +66,7 @@ date: git Last Modified
                 {% renderTeamMember maintainer %}
             {%- endfor -%}
             <div class="text-sm pb-1 text-right mb-4"><a href="{{ page | handbookEditLink }}">Edit this page</a></div>
-            <div class="text-xs pb-1 text-right mb-4 italic">Updated: {{ page.date | shortDate }}</div>
+            <div class="text-xs pb-1 text-right mb-4 italic">Updated: {% filter shortDate %}{{ updated if updated else page.date }}{% endfilter %}</div>
         </div>
     </div>
 </div>


### PR DESCRIPTION
Fixes https://github.com/flowforge/flowforge/issues/2592
## Description

We use the `handbook.njk` template for both the docs and the handbook pages.

The handbook pages come from the same repo - so their `page.date` is set to their last modified date already.

The docs pages are copied in, so we cannot use their `page.date`. The copy script already adds an `updated` entry to each files metadata yml. This PR updates the template to use that value if present. This ensures the 'last updated' date is correct for both handbook and docs pages.

For some reason, the `spacetime` module didn't like the date format coming from the docs pages. But wrapping it in a Date object made it happy.

