### PR TITLE
support: Rebrand our community forum to FlowFuse

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -183,7 +183,7 @@
                                         {% navoption "blog", "/blog", 2, "newspaper" %}{% endnavoption %}
                                         {% navoption "webinars", "/webinars", 2, "screen" %}{% endnavoption %}
                                         {% navoption "newsletters", "/community/newsletter/", 2, "mail-open" %}{% endnavoption %}
-                                        {% navoption "support forums", "https://community.flowforge.com/", 2, "star" %}{% endnavoption %}
+                                        {% navoption "support forums", "https://community.flowfuse.com/", 2, "star" %}{% endnavoption %}
                                     </ul>
                                 </div>
                             </ul>

--- a/src/_includes/layouts/post.njk
+++ b/src/_includes/layouts/post.njk
@@ -43,7 +43,7 @@ layout: layouts/base.njk
                 </div>
                 <script type="text/javascript">
                     window.DiscourseEmbed = {
-                        discourseUrl: 'https://community.flowforge.com/',
+                        discourseUrl: 'https://community.flowfuse.com/',
                         discourseEmbedUrl: "{{ site.baseURL }}{{ page.url }}",
                         className: 'ff-comment-thread'
                     };

--- a/src/blog/2023/06/flowforge-1-8-released.md
+++ b/src/blog/2023/06/flowforge-1-8-released.md
@@ -94,5 +94,5 @@ guide for [upgrading your FlowFuse instance](https://flowforge.com/docs/upgrade/
 
 ## Getting help
 
-Please check FlowFuse's [documentation](https://flowforge.com/docs/) as the answers to many questions are covered there. Additionally you can go the the [community forum](https://community.flowforge.com) if you have
+Please check FlowFuse's [documentation](https://flowforge.com/docs/) as the answers to many questions are covered there. Additionally you can go the the [community forum](https://community.flowfuse.com) if you have
 any feedback or feature requests.

--- a/src/blog/2023/06/introducing-the-flowforge-community-forum.md
+++ b/src/blog/2023/06/introducing-the-flowforge-community-forum.md
@@ -10,7 +10,7 @@ tags:
 image: # /images/blog/tile-needed.jpg
 ---
 
-We are thrilled to announce the launch of the [Community Forum for FlowFuse](https://community.flowforge.com).
+We are thrilled to announce the launch of the [Community Forum for FlowFuse](https://community.flowfuse.com).
 A forum dedicated to empowering developers and enthusiasts to create innovative
 applications using FlowFuse, Node-RED and related technologies. 
 

--- a/src/blog/2023/07/flowforge-1-9-3-release.md
+++ b/src/blog/2023/07/flowforge-1-9-3-release.md
@@ -57,5 +57,5 @@ guide for [upgrading your FlowFuse instance](https://flowforge.com/docs/upgrade/
 
 ## Getting help
 
-Please check FlowFuse's [documentation](https://flowforge.com/docs/) as the answers to many questions are covered there. Additionally you can go the the [community forum](https://community.flowforge.com) if you have
+Please check FlowFuse's [documentation](https://flowforge.com/docs/) as the answers to many questions are covered there. Additionally you can go the the [community forum](https://community.flowfuse.com) if you have
 any feedback or feature requests.

--- a/src/blog/2023/07/flowforge-1-9-release.md
+++ b/src/blog/2023/07/flowforge-1-9-release.md
@@ -83,5 +83,5 @@ guide for [upgrading your FlowFuse instance](https://flowforge.com/docs/upgrade/
 
 ## Getting help
 
-Please check FlowFuse's [documentation](https://flowforge.com/docs/) as the answers to many questions are covered there. Additionally you can go the the [community forum](https://community.flowforge.com) if you have
+Please check FlowFuse's [documentation](https://flowforge.com/docs/) as the answers to many questions are covered there. Additionally you can go the the [community forum](https://community.flowfuse.com) if you have
 any feedback or feature requests.

--- a/src/blog/2023/08/flowforge-1-10-release.md
+++ b/src/blog/2023/08/flowforge-1-10-release.md
@@ -72,5 +72,5 @@ guide for [upgrading your FlowFuse instance](https://flowforge.com/docs/upgrade/
 
 ## Getting help
 
-Please check FlowFuse's [documentation](https://flowforge.com/docs/) as the answers to many questions are covered there. Additionally you can go the the [community forum](https://community.flowforge.com) if you have
+Please check FlowFuse's [documentation](https://flowforge.com/docs/) as the answers to many questions are covered there. Additionally you can go the the [community forum](https://community.flowfuse.com) if you have
 any feedback or feature requests.

--- a/src/handbook/operations/customer-success.md
+++ b/src/handbook/operations/customer-success.md
@@ -134,4 +134,4 @@ itself or their flows should be redirected to the
 customer direct to a repo for a 3rd party node question.
 
 [support-tickets]: ../../support/
-[support-forum]: https://community.flowforge.com
+[support-forum]: https://community.flowfuse.com

--- a/src/support.njk
+++ b/src/support.njk
@@ -38,7 +38,7 @@ sitemapPriority: 0.8
           </div>
           <div
             class="container text-center max-w-4xl flex flex-col md:items-start mt-6">
-            <a class="ff-btn ff-btn--primary flex flex-col" href="https://community.flowforge.com/">
+            <a class="ff-btn ff-btn--primary flex flex-col" href="https://community.flowfuse.com/">
               <span class="text-base uppercase no-underline md:px-4">
                 COMMUNITY FORUM
               </span>


### PR DESCRIPTION
Updating links to make sure the new destination is where visitors end up at.

## Related Issue(s)

<!-- What issue does this PR relate to? -->
