### PR TITLE
Make your builds faster with this simple trick!

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "clean:dev": "cross-env npx del-cli '_site/!(img)' 'src/docs/**/*.md' && cross-env npx mkdirp '_site/js'",
         "clean": "cross-env npx del-cli '_site/' && cross-env mkdir -p '_site/js'",
         "dev:docs": "node scripts/dirExists ../flowforge/docs && nodemon -w ../flowforge/docs -e md --exec \"npm run docs\" || echo \"docs not found - skipping...\"",
-        "dev:netlify": "npx netlify dev",
+        "dev:netlify": "npx netlify dev -c \"cross-env npx @11ty/eleventy --serve --quiet --incremental\"",
         "dev:postcss": "cross-env TAILWIND_MODE=watch npx postcss ./src/css/style.css -o ./_site/css/style.css --config ./postcss.config.js -w",
         "docs": "node scripts/copy_docs.js",
         "old_dev:eleventy": "cross-env NODE_ENV=development ELEVENTY_ENV=development npx @11ty/eleventy --serve --quiet",


### PR DESCRIPTION
Before this change each save of a file would take 6.5 seconds on my laptop before the site was regenerated. In development scenario's that's slow.

By leveraging Eleventy's incremental builds feature this is slashed to 3.0s. While still slow, it's much better.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
