### PR TITLE
blog: Update tag to FlowFuse

### DIFF
--- a/src/_data/blogTags.json
+++ b/src/_data/blogTags.json
@@ -6,7 +6,7 @@
     "value": "node-red"
 },  {
     "label": "FlowFuse",
-    "value": "flowforge"
+    "value": "flowfuse"
 }, {
     "label": "How-To",
     "value": "how-to"

--- a/src/blog/2021/04/first-deploy.md
+++ b/src/blog/2021/04/first-deploy.md
@@ -5,7 +5,7 @@ description: Building a new low-code development platform around the Node-RED pr
 date: 2021-04-06
 authors: ["nick-oleary"]
 tags:
-    - flowforge
+    - flowfuse
     - news
 ---
 When Dave and I first created [Node-RED](https://nodered.org), it was a tool to solve a

--- a/src/blog/2021/05/welcome-ben.md
+++ b/src/blog/2021/05/welcome-ben.md
@@ -4,7 +4,7 @@ description: Welcoming Ben Hardill to FlowFuse Inc.
 date: 2021-05-10
 authors: ["nick-oleary"]
 tags:
-    - flowforge
+    - flowfuse
     - news
 ---
 I'm excited to share the news that Ben Hardill ([@hardillb](https://twitter.com/hardillb)) is joining FlowFuse as a Senior Engineer.

--- a/src/blog/2022/01/flowforge-01-released.md
+++ b/src/blog/2022/01/flowforge-01-released.md
@@ -6,7 +6,7 @@ date: 2022-01-20 1:00:00.0
 authors: ["nick-oleary"]
 tags:
     - posts
-    - flowforge
+    - flowfuse
     - releases
 ---
 

--- a/src/blog/2022/01/welcome-steve.md
+++ b/src/blog/2022/01/welcome-steve.md
@@ -5,7 +5,7 @@ date: 2022-01-20
 authors: ["nick-oleary"]
 tags:
     - posts
-    - flowforge
+    - flowfuse
     - news
 ---
 

--- a/src/blog/2022/01/welcome-zj.md
+++ b/src/blog/2022/01/welcome-zj.md
@@ -5,7 +5,7 @@ date: 2022-01-03
 authors: ["nick-oleary"]
 tags:
     - posts
-    - flowforge
+    - flowfuse
     - news
 ---
 

--- a/src/blog/2022/02/announcing-flowforge-cloud.md
+++ b/src/blog/2022/02/announcing-flowforge-cloud.md
@@ -6,7 +6,7 @@ date: 2022-02-23 19:44:00.0
 authors: ["zeger-jan-van-de-weg"]
 tags:
     - posts
-    - flowforge
+    - flowfuse
     - news
     - releases
 ---

--- a/src/blog/2022/02/flowforge-02-released.md
+++ b/src/blog/2022/02/flowforge-02-released.md
@@ -6,7 +6,7 @@ date: 2022-02-17 1:00:00.0
 authors: ["nick-oleary"]
 tags:
     - posts
-    - flowforge
+    - flowfuse
     - releases
 ---
 

--- a/src/blog/2022/02/welcome-joe.md
+++ b/src/blog/2022/02/welcome-joe.md
@@ -5,7 +5,7 @@ date: 2022-02-08
 authors: ["nick-oleary"]
 tags:
     - posts
-    - flowforge
+    - flowfuse
     - news
 ---
 

--- a/src/blog/2022/03/flowforge-03-released.md
+++ b/src/blog/2022/03/flowforge-03-released.md
@@ -6,7 +6,7 @@ date: 2022-03-17 1:00:00.0
 authors: ["nick-oleary"]
 tags:
     - posts
-    - flowforge
+    - flowfuse
     - releases
 ---
 
@@ -95,7 +95,7 @@ raise an [issue on GitHub](https://github.com/flowforge/flowforge/issues).
 
 That also includes if you have any feedback or feature requests.
 
-We also have a `#flowforge` channel on the [Node-RED Slack workspace](https://nodered.org/slack).
+We also have a `#flowfuse` channel on the [Node-RED Slack workspace](https://nodered.org/slack).
 
 ### What's next?
 

--- a/src/blog/2022/04/flowforge-04-released.md
+++ b/src/blog/2022/04/flowforge-04-released.md
@@ -6,7 +6,7 @@ date: 2022-04-14 12:00:00.0
 authors: ["sam-machin"]
 tags:
     - posts
-    - flowforge
+    - flowfuse
     - releases
 ---
 

--- a/src/blog/2022/04/flowforge-accepting-customers.md
+++ b/src/blog/2022/04/flowforge-accepting-customers.md
@@ -6,7 +6,7 @@ date: 2022-04-04
 authors: ["zeger-jan-van-de-weg"]
 tags:
     - posts
-    - flowforge
+    - flowfuse
     - news
 ---
 

--- a/src/blog/2022/05/flowforge-05-released.md
+++ b/src/blog/2022/05/flowforge-05-released.md
@@ -6,7 +6,7 @@ date: 2022-05-12 12:00:00.0
 authors: ["nick-oleary"]
 tags:
     - posts
-    - flowforge
+    - flowfuse
     - releases
 ---
 

--- a/src/blog/2022/05/sign-up-for-flowforge-cloud.md
+++ b/src/blog/2022/05/sign-up-for-flowforge-cloud.md
@@ -6,7 +6,7 @@ date: 2022-05-25 09:00:00.0
 authors: ["zeger-jan-van-de-weg"]
 tags:
     - posts
-    - flowforge
+    - flowfuse
     - news
 ---
 

--- a/src/blog/2022/06/flowforge-06-released.md
+++ b/src/blog/2022/06/flowforge-06-released.md
@@ -6,7 +6,7 @@ date: 2022-06-19 12:00:00.0
 authors: ["nick-oleary"]
 tags:
     - posts
-    - flowforge
+    - flowfuse
     - releases
 ---
 
@@ -79,4 +79,4 @@ raise an [issue on GitHub](https://github.com/flowforge/flowforge/issues).
 
 That also includes if you have any feedback or feature requests.
 
-We also have a `#flowforge` channel on the [Node-RED Slack workspace](https://nodered.org/slack).
+We also have a `#flowfuse` channel on the [Node-RED Slack workspace](https://nodered.org/slack).

--- a/src/blog/2022/07/flowforge-07-released.md
+++ b/src/blog/2022/07/flowforge-07-released.md
@@ -7,7 +7,7 @@ authors: ["sam-machin"]
 video: rl_Ln2_uEtg
 tags:
     - posts
-    - flowforge
+    - flowfuse
     - releases
 ---
 Rollback projects to a previous snapshot, improvements in using Devices, and more.

--- a/src/blog/2022/07/new-projecttype.md
+++ b/src/blog/2022/07/new-projecttype.md
@@ -6,7 +6,7 @@ date: 2022-07-22 12:00:00.0
 authors: ["sam-machin"]
 tags:
     - posts
-    - flowforge
+    - flowfuse
     - news
 ---
 We've added a second size of project to FlowFuse Cloud. A bigger project type with more resources available to it.

--- a/src/blog/2022/08/flowforge-08-released.md
+++ b/src/blog/2022/08/flowforge-08-released.md
@@ -7,7 +7,7 @@ authors: ["sam-machin"]
 video: nCe_qs0G6ZQ
 tags:
     - posts
-    - flowforge
+    - flowfuse
     - releases
 ---
 
@@ -78,4 +78,4 @@ That also includes if you have any feedback or feature requests.
 
 Customers of FlowFuse Cloud can raise a ticket by emailing support@flowfuse.com
 
-We also have a `#flowforge` channel on the [Node-RED Slack workspace](https://nodered.org/slack).
+We also have a `#flowfuse` channel on the [Node-RED Slack workspace](https://nodered.org/slack).

--- a/src/blog/2022/09/flowforge-010-released.md
+++ b/src/blog/2022/09/flowforge-010-released.md
@@ -7,7 +7,7 @@ authors: ["rob-marcer"]
 video: mjR1iiEFiBg
 tags:
     - posts
-    - flowforge
+    - flowfuse
     - releases
 ---
 
@@ -79,4 +79,4 @@ That also includes if you have any feedback or feature requests.
 
 Customers of FlowFuse Cloud can raise a ticket by emailing support@flowfuse.com
 
-We also have a `#flowforge` channel on the [Node-RED Slack workspace](https://nodered.org/slack).
+We also have a `#flowfuse` channel on the [Node-RED Slack workspace](https://nodered.org/slack).

--- a/src/blog/2022/09/flowforge-09-released.md
+++ b/src/blog/2022/09/flowforge-09-released.md
@@ -7,7 +7,7 @@ authors: ["sam-machin"]
 video: d23Pmyc0k7I
 tags:
     - posts
-    - flowforge
+    - flowfuse
     - releases
 ---
 

--- a/src/blog/2022/09/static-ips.md
+++ b/src/blog/2022/09/static-ips.md
@@ -6,7 +6,7 @@ date: 2022-09-27
 authors: ["rob-marcer"]
 tags:
     - posts
-    - flowforge
+    - flowfuse
     - news
 ---
 

--- a/src/blog/2022/10/db-migration-01.md
+++ b/src/blog/2022/10/db-migration-01.md
@@ -6,7 +6,7 @@ date: 2022-10-18
 authors: ["ben-hardill"]
 tags:
     - posts
-    - flowforge
+    - flowfuse
     - news
 ---
 

--- a/src/blog/2022/10/ff-docker-gcp.md
+++ b/src/blog/2022/10/ff-docker-gcp.md
@@ -6,7 +6,7 @@ date: 2022-10-14
 authors: ["rob-marcer"]
 tags:
     - posts
-    - flowforge
+    - flowfuse
     - how-to
 ---
 

--- a/src/blog/2022/10/flowforge-1-released.md
+++ b/src/blog/2022/10/flowforge-1-released.md
@@ -7,7 +7,7 @@ authors: ["rob-marcer"]
 video: 5TLT7CQR7iI
 tags:
     - posts
-    - flowforge
+    - flowfuse
     - releases
 ---
 
@@ -81,4 +81,4 @@ That also includes if you have any feedback or feature requests.
 
 Customers of FlowFuse Cloud can raise a ticket by emailing support@flowfuse.com
 
-We also have a `#flowforge` channel on the [Node-RED Slack workspace](https://nodered.org/slack).
+We also have a `#flowfuse` channel on the [Node-RED Slack workspace](https://nodered.org/slack).

--- a/src/blog/2022/10/seed-round-bring-node-red-to-enterprise.md
+++ b/src/blog/2022/10/seed-round-bring-node-red-to-enterprise.md
@@ -6,7 +6,7 @@ date: 2022-11-03 17:00:00.0
 authors: ["zeger-jan-van-de-weg"]
 tags:
     - posts
-    - flowforge
+    - flowfuse
     - news
 ---
 

--- a/src/blog/2022/11/flowforge-1-1-released.md
+++ b/src/blog/2022/11/flowforge-1-1-released.md
@@ -7,7 +7,7 @@ authors: ["rob-marcer"]
 video: 134iljE_urI
 tags:
     - posts
-    - flowforge
+    - flowfuse
     - releases
 ---
 

--- a/src/blog/2022/11/respin-docker-compose-01.md
+++ b/src/blog/2022/11/respin-docker-compose-01.md
@@ -6,7 +6,7 @@ date: 2022-11-25
 authors: ["ben-hardill"]
 tags:
     - posts
-    - flowforge
+    - flowfuse
     - news
 ---
 

--- a/src/blog/2022/12/flowforge-1-1-2-released.md
+++ b/src/blog/2022/12/flowforge-1-1-2-released.md
@@ -6,7 +6,7 @@ date: 2022-12-09 12:00:00.0
 authors: ["nick-oleary"]
 tags:
     - posts
-    - flowforge
+    - flowfuse
     - releases
 ---
 
@@ -58,9 +58,9 @@ guide for [upgrading your FlowFuse instance](/docs/upgrade/)
 
 Please check FlowFuse's [documentation](/docs/) as the answers to many questions are covered there.
 
-If you hit any problems with the platform, please raise an [issue on GitHub](https://github.com/flowforge/flowforge/issues).
+If you hit any problems with the platform, please raise an [issue on GitHub](https://github.com/flowfuse/flowfuse/issues).
 That also includes if you have any feedback or feature requests.
 
-Chat with us on the `#flowforge` channel on the [Node-RED Slack workspace](https://nodered.org/slack).
+Chat with us on the `#flowfuse` channel on the [Node-RED Slack workspace](https://nodered.org/slack).
 
 You can also raise a support ticket by emailing [support@flowfuse.com](mailto:support@flowfuse.com)

--- a/src/blog/2022/12/flowforge-1-1-2-released.md
+++ b/src/blog/2022/12/flowforge-1-1-2-released.md
@@ -58,7 +58,7 @@ guide for [upgrading your FlowFuse instance](/docs/upgrade/)
 
 Please check FlowFuse's [documentation](/docs/) as the answers to many questions are covered there.
 
-If you hit any problems with the platform, please raise an [issue on GitHub](https://github.com/flowfuse/flowfuse/issues).
+If you hit any problems with the platform, please raise an [issue on GitHub](https://github.com/flowforge/flowforge/issues).
 That also includes if you have any feedback or feature requests.
 
 Chat with us on the `#flowfuse` channel on the [Node-RED Slack workspace](https://nodered.org/slack).

--- a/src/blog/2022/12/flowforge-gcp-https-set-up.md
+++ b/src/blog/2022/12/flowforge-gcp-https-set-up.md
@@ -6,7 +6,7 @@ date: 2022-12-09
 authors: ["rob-marcer"]
 tags:
     - posts
-    - flowforge
+    - flowfuse
     - how-to
 ---
 

--- a/src/blog/2022/12/flowforge-joins-openjs-foundation.md
+++ b/src/blog/2022/12/flowforge-joins-openjs-foundation.md
@@ -6,7 +6,7 @@ date: 2022-12-13 12:00:00.0
 authors: ["nick-oleary"]
 tags:
     - posts
-    - flowforge
+    - flowfuse
     - news
 ---
 

--- a/src/blog/2022/12/what-flowforge-adds-to-node-red.md
+++ b/src/blog/2022/12/what-flowforge-adds-to-node-red.md
@@ -6,7 +6,7 @@ date: 2022-12-15
 authors: ["rob-marcer"]
 tags:
     - posts
-    - flowforge
+    - flowfuse
     - node-red
 ---
 

--- a/src/blog/2023/01/flowforge-1-3-0-released.md
+++ b/src/blog/2023/01/flowforge-1-3-0-released.md
@@ -8,7 +8,7 @@ video: ey3xv5j5x7k
 image: /blog/2023/01/images/flowforge-130-hero.png
 tags:
     - posts
-    - flowforge
+    - flowfuse
     - releases
 ---
 

--- a/src/blog/2023/01/flowforge-1.2.1-released.md
+++ b/src/blog/2023/01/flowforge-1.2.1-released.md
@@ -6,7 +6,7 @@ date: 2023-01-12 12:00:00.0
 authors: ["ben-hardill"]
 tags:
     - posts
-    - flowforge
+    - flowfuse
     - releases
 ---
 

--- a/src/blog/2023/01/flowforge-story.md
+++ b/src/blog/2023/01/flowforge-story.md
@@ -6,7 +6,7 @@ date: 2023-02-02
 authors: ["ian-skerrett"]
 tags:
     - posts
-    - flowforge
+    - flowfuse
 ---
 
 During my first month at FlowFuse, I have been helping to refine the FlowFuse story. Trying to answer the questions: What is the value FlowFuse brings to our customers and what features does FlowFuse want to offer the Node-RED community?

--- a/src/blog/2023/02/flowforge-1-4-0-released.md
+++ b/src/blog/2023/02/flowforge-1-4-0-released.md
@@ -8,7 +8,7 @@ video: vbg4zTmUYjQ
 image: /blog/2023/02/images/ff-r14-image.png
 tags:
     - posts
-    - flowforge
+    - flowfuse
     - releases
 ---
 

--- a/src/blog/2023/02/highly-available-node-red.md
+++ b/src/blog/2023/02/highly-available-node-red.md
@@ -8,7 +8,7 @@ image: /blog/2023/02/images/roadmap-unsplash.jpg
 tags:
     - posts
     - node-red
-    - flowforge
+    - flowfuse
 ---
 
 Over the past few months we've held a lot of product discovery sessions and a topic

--- a/src/blog/2023/02/service-disruption-report-2023-01-27.md
+++ b/src/blog/2023/02/service-disruption-report-2023-01-27.md
@@ -4,7 +4,7 @@ date: 2023-02-10
 authors: ["nick-oleary"]
 tags:
     - posts 
-    - flowforge
+    - flowfuse
     - news
 ---
 

--- a/src/blog/2023/03/flowforge-1-5-0-released.md
+++ b/src/blog/2023/03/flowforge-1-5-0-released.md
@@ -7,7 +7,7 @@ authors: ["joe-pavitt"]
 image: /blog/2023/03/images/release-150.jpg
 tags:
     - posts
-    - flowforge
+    - flowfuse
     - releases
 ---
 

--- a/src/blog/2023/03/terminology-changes.md
+++ b/src/blog/2023/03/terminology-changes.md
@@ -7,7 +7,7 @@ authors: ["joe-pavitt"]
 image: /blog/2023/03/images/concept-changes.png
 tags:
     - posts
-    - flowforge
+    - flowfuse
     - news
 ---
 

--- a/src/blog/2023/04/flowforge-1-6-released.md
+++ b/src/blog/2023/04/flowforge-1-6-released.md
@@ -7,7 +7,7 @@ authors: ["ian-skerrett"]
 image: /blog/2023/04/images/release-1.6.0.png
 tags:
     - posts
-    - flowforge
+    - flowfuse
     - releases
 ---
 

--- a/src/blog/2023/04/hannover-messe.md
+++ b/src/blog/2023/04/hannover-messe.md
@@ -7,7 +7,7 @@ authors: ["marian-demme"]
 image: /blog/2023/04/images/HMI2023.png
 tags:
     - posts
-    - flowforge
+    - flowfuse
     - node-red
     - community
 ---

--- a/src/blog/2023/05/device-agent-as-a-service.md
+++ b/src/blog/2023/05/device-agent-as-a-service.md
@@ -7,7 +7,7 @@ authors: ["rob-marcer"]
 image: /blog/2023/05/images/agent-on-pi.png
 tags:
     - posts
-    - flowforge
+    - flowfuse
     - how-to
 ---
 

--- a/src/blog/2023/05/flowforge-1-7-released.md
+++ b/src/blog/2023/05/flowforge-1-7-released.md
@@ -7,7 +7,7 @@ authors: ["marian-demme"]
 image: /blog/2023/05/images/release-1.7.0.png
 tags:
     - posts
-    - flowforge
+    - flowfuse
     - releases
 ---
 

--- a/src/blog/2023/06/flowforge-1-8-released.md
+++ b/src/blog/2023/06/flowforge-1-8-released.md
@@ -7,7 +7,7 @@ authors: ["marian-demme"]
 image: /blog/2023/06/images/release-1.8.0.png
 tags:
     - posts
-    - flowforge
+    - flowfuse
     - releases
 ---
 

--- a/src/blog/2023/06/introducing-the-flowforge-community-forum.md
+++ b/src/blog/2023/06/introducing-the-flowforge-community-forum.md
@@ -6,7 +6,7 @@ date: 2023-06-12 12:00:00
 authors: ["zeger-jan-van-de-weg"]
 tags:
   - news
-  - flowforge
+  - flowfuse
 image: # /images/blog/tile-needed.jpg
 ---
 

--- a/src/blog/2023/07/flowforge-1-9-3-release.md
+++ b/src/blog/2023/07/flowforge-1-9-3-release.md
@@ -6,7 +6,7 @@ date: 2023-07-21
 authors: ["nick-oleary"]
 tags:
     - posts
-    - flowforge
+    - flowfuse
     - releases
 ---
 

--- a/src/blog/2023/07/flowforge-1-9-release.md
+++ b/src/blog/2023/07/flowforge-1-9-release.md
@@ -7,7 +7,7 @@ authors: ["ian-skerrett"]
 image: /blog/2023/07/images/release-1.9.0.png
 tags:
     - posts
-    - flowforge
+    - flowfuse
     - releases
 ---
 

--- a/src/blog/2023/07/how-to-build-a-opc-client-dashboard-in-node-red.md
+++ b/src/blog/2023/07/how-to-build-a-opc-client-dashboard-in-node-red.md
@@ -7,7 +7,7 @@ authors: ["richard-meyer"]
 image: blog/2023/07/images/opc-ua-3/opc-ua-3-title-image.png
 tags:
     - posts
-    - flowforge
+    - flowfuse
     - node-red
 ---
 This article is the third and final part of our OPC UA content series. In the [first article](/blog/2023/07/how-to-deploy-a-basic-opc-ua-server-in-node-red/), we cover some OPC UA fundamentals and walk through an example OPC UA Server flow. In the [second article](/blog/2023/07/how-to-build-a-secure-opc-ua-server-for-plcs-in-node-red/), we built a SSL-secured OPC UA server using data from an Allen Bradley PLC as a source. 

--- a/src/blog/2023/07/how-to-build-a-secure-opc-ua-server-for-plcs-in-node-red.md
+++ b/src/blog/2023/07/how-to-build-a-secure-opc-ua-server-for-plcs-in-node-red.md
@@ -7,7 +7,7 @@ authors: ["richard-meyer"]
 image: blog/2023/07/images/opc-ua-2/opc-ua-2-title-image.png
 tags:
     - posts
-    - flowforge
+    - flowfuse
     - node-red
 ---
 This article is the second part of a series of OPC-UA content. In [part one](/blog/2023/07/how-to-deploy-a-basic-opc-ua-server-in-node-red/),

--- a/src/blog/2023/07/how-to-deploy-a-basic-opc-ua-server-in-node-red.md
+++ b/src/blog/2023/07/how-to-deploy-a-basic-opc-ua-server-in-node-red.md
@@ -7,7 +7,7 @@ authors: ["richard-meyer"]
 image: blog/2023/07/images/opc-ua-1/opc-ua-1-title-image.png
 tags:
     - posts
-    - flowforge
+    - flowfuse
     - node-red
 ---
 

--- a/src/blog/2023/07/images-in-node-red-dashboards.md
+++ b/src/blog/2023/07/images-in-node-red-dashboards.md
@@ -7,7 +7,7 @@ authors: ["rob-marcer"]
 image: blog/2023/07/images/add-images-in-node-red-header.png
 tags:
     - posts
-    - flowforge
+    - flowfuse
     - node-red
 ---
 

--- a/src/blog/2023/08/flowforge-1-10-release.md
+++ b/src/blog/2023/08/flowforge-1-10-release.md
@@ -7,7 +7,7 @@ authors: ["ian-skerrett"]
 image: /blog/2023/08/images/release-1-10-graphic.png
 tags:
     - posts
-    - flowforge
+    - flowfuse
     - releases
 ---
 

--- a/src/blog/flowfuse.njk
+++ b/src/blog/flowfuse.njk
@@ -2,7 +2,7 @@
 layout: nohero
 sitemapPriority: 0.8
 pagination:
-  data: collections.flowforge
+  data: collections.flowfuse
   size: 19 # creates a nice matrix (1 header, 18 left: 3 on 6 rows)
   alias: posts
   reverse: true


### PR DESCRIPTION
The tags on the blog overview are now updated to read FlowFuse