### PR TITLE
liquid: Render `{{` correctly

### DIFF
--- a/src/_includes/core-nodes/template-use-case.md
+++ b/src/_includes/core-nodes/template-use-case.md
@@ -13,13 +13,15 @@ You can connect the Template node to a source of data, such as an MQTT input, HT
 In the Template node configuration, you define the template using text based formatting languages like HTML with the Mustache syntax.
 Mustache is a simple and "logic-less" templating language that allows you to insert variables and expressions into your template.
 
-For example, you can define a template like this: `<p>Hello {{payload.name}}!</p>`.
+For example, you can define a template like this: {% raw %}`<p>Hello {{payload.name}}!</p>`{% endraw %}.
 
 ![HTML Template with Mustache](./images/template-mustache.png "HTML template with Mustache")
 
+{% raw %}
 ```json
 [{"id":"97d742eec1cb7dbf","type":"inject","z":"a6b7ede2e13fcbdf","name":"","props":[{"p":"payload"},{"p":"topic","vt":"str"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","payload":"{\"name\": \"FlowFuse\"}","payloadType":"json","x":180,"y":60,"wires":[["c85d70b41f374f02"]]},{"id":"c85d70b41f374f02","type":"template","z":"a6b7ede2e13fcbdf","name":"Template using payload.name","field":"payload","fieldType":"msg","format":"handlebars","syntax":"mustache","template":"<p>Hello {{payload.name}}!</p>","output":"str","x":450,"y":60,"wires":[["6df7215459dfb240"]]},{"id":"6df7215459dfb240","type":"debug","z":"a6b7ede2e13fcbdf","name":"Print \"<p>Hello, FlowFuse!</p>\"","active":true,"tosidebar":true,"console":false,"tostatus":false,"complete":"payload","targetType":"msg","statusVal":"","statusType":"auto","x":750,"y":60,"wires":[]}]
 ```
+{% endraw %}
 
 This example will output `<p>Hello FlowFuse!</p>`.
 


### PR DESCRIPTION
As the markdown in our website is preprocessed by Liquid, the `{{` need escaping with the `{% raw %}`. That part was left out by me in 1dfd90aeeee174b871846b566d54893ba79e35c6

With this change it renders correctly.

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
