### PR TITLE
hyperlink: src dir is relative

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,6 @@ jobs:
       - name: Test the website
         run: npm run test
         working-directory: 'website'
-      - uses: untitaker/hyperlink@0.1.27
+      - uses: untitaker/hyperlink@0.1.31
         with:
           args: website/_site/ --check-anchors --sources ../src

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,4 +30,4 @@ jobs:
         working-directory: 'website'
       - uses: untitaker/hyperlink@0.1.31
         with:
-          args: website/_site/ --check-anchors --sources ../src
+          args: website/_site/ --check-anchors --sources website/src

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,4 +30,4 @@ jobs:
         working-directory: 'website'
       - uses: untitaker/hyperlink@0.1.27
         with:
-          args: website/_site/ --check-anchors --sources src
+          args: website/_site/ --check-anchors --sources ../src

--- a/src/blog/2023/09/tulip-event-report.md
+++ b/src/blog/2023/09/tulip-event-report.md
@@ -9,7 +9,7 @@ tags:
     - posts
     - flowfuse
 ---
-This week I attended the Tulip event called [Operations Calling](operationscalling) in Boston. Here are some quick observations from the event.
+This week I attended the Tulip event called [Operations Calling](https://www.operationscalling.com/) in Boston. Here are some quick observations from the event.
 
 <!--more-->
 


### PR DESCRIPTION
## Description

In a previous commit, f71ebde78ad13f416eb4981eb41719993107b516, I broke the tests for this repository. As the script working dir is `/home/runner/work/_actions/untitaker/hyperlink/0.1.27/scripts/hyperlink-bin website/_site/ `, the source directory is at the parent dir. so `../src`.


## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] I have considered the performance impact of these changes
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
