### PR TITLE
Fix outdated image URL & flow viewer subtitle

### DIFF
--- a/src/blog/2023/08/dashboard-community-update.md
+++ b/src/blog/2023/08/dashboard-community-update.md
@@ -27,15 +27,15 @@ Below you'll find a summary of the changes we've made since our [last community 
 
 Steve has been doing some incredible work on the new `ui-template` widget. This widget allows you to create your own custom components using raw HTML, but also works with any of the components in the [Vuetify](https://vuetifyjs.com/en/components/all/) component library. It's a powerful tool that will enable users to be creative with their own widgets that are not currently available with the standard set of widgets.
 
-![Examples of ui-template](https://flowforge.github.io/flowforge-nr-dashboard/assets/ui-template.9d278589.png)
+![Examples of ui-template](https://dashboard.flowfuse.com/images/node-examples/ui-template.png)
 
 The Template node also provides access to two built-in functions that can be used to send data back to Node-RED:
 - **send(msg)**: Outputs a message (defined by the input to this function call) from this node in the Node-RED flow.
 - **submit()**: Send a `FormData` object when attached to a `<form>` element. The created object will consist of the `name` attributes for each form element, corresponding to their respective `value` attributes.
 
-### Toggle Switch (<a href="https://flowforge.github.io/flowforge-nr-dashboard/nodes/widgets/ui-switch.html" target="_blank">docs</a>)
+### Toggle Switch (<a href="https://dashboard.flowfuse.com/nodes/widgets/ui-switch.html" target="_blank">docs</a>)
 
-![Examples of ui-switch](https://flowforge.github.io/flowforge-nr-dashboard/assets/ui-switch.fb5583c2.png)
+![Examples of ui-switch](https://dashboard.flowfuse.com/images/node-examples/ui-switch.png)
 
 Adds a toggle switch to the user interface that can be rendered with a label, and traditional toggle switch, or, as in Dashboard 1.0, can be a square element with an icon & colour provided.
 

--- a/src/blog/2023/09/flow-viewer.md
+++ b/src/blog/2023/09/flow-viewer.md
@@ -1,7 +1,7 @@
 ---
 title: Share & Preview Flows on flows.nodered.org
-subtitle: Your monthly update for the FlowFuse and Node-RED communities
-description: News from the FlowFuse and Node-RED communities
+subtitle: FlowFuse has just contributed an interactive "Flow Viewer" to flows.nodered.org, allowing users to preview flows, and embed them in articles & forum posts.
+description: FlowFuse has just contributed an interactive "Flow Viewer" to flows.nodered.org, allowing users to preview flows, and embed them in articles & forum posts.
 date: 2023-09-20
 authors: ["joe-pavitt"]
 image: "/blog/2023/09/images/tile-flowviewer.jpg"


### PR DESCRIPTION
## Description

- With the Dashboard doc images now being served as static assets, their URL changed, this updates the pointer in an older article
- I had accidentally not updated the subtitle/description of the recently published Flow Viewer article, this updates them.