### PR TITLE
Fix self-hosted devops pricing

### DIFF
--- a/src/_includes/feature_lists/self-hosted.njk
+++ b/src/_includes/feature_lists/self-hosted.njk
@@ -33,11 +33,6 @@
             values: ['check', 'check', 'check'],
             info: "<p>Keep track of everything going on in your Node-RED instances and FlowForge.</p><p>Audit Logs provide details on what actions have taken place, when they happened, and who did them.</p>"
         }, {
-            id: "pipelines",
-            label: "DevOps Pipelines",
-            values: ['check', 'check', 'check'],
-            info: "<p>DevOps pipelines allows for you to setup different environments for development, testing and production Node-RED instances.</p>"
-        }, {
             id: "device-mgmt",
             label: "Device Management",
             values: ['check', 'check', 'check'],
@@ -52,6 +47,11 @@
             label: "Endpoint Security",
             values: ['None/HTTP Basic Auth/FF Auth', 'None/HTTP Basic Auth/FF Auth', 'None/HTTP Basic Auth/FF Auth'],
             info: "<p>Tooltip info here</p>"
+        }, {
+            id: "pipelines",
+            label: "DevOps Pipelines",
+            values: [null, 'check', 'check'],
+            info: "<p>DevOps pipelines allows for you to setup different environments for development, testing and production Node-RED instances.</p>"
         }, {
             id: "project-nodes",
             label: "Seamless Data Stream",


### PR DESCRIPTION
## Description

Our current pricing page shows DevOps Pipelines as being available to all self-hosted tiers.

It should only be available to licensed users. This PR updates the table - moving the pipelines row down so that it doesn't create a 'gap' in the OSS/Starter column.